### PR TITLE
fix: address priority findings from full-branch code review

### DIFF
--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -76,7 +76,8 @@ jobs:
             sleep 30
           done
           echo "Release $TAG not found after 15 minutes, creating it"
-          gh release create "$TAG" --generate-notes
+          # Tolerate races with the parallel jammy/noble jobs and the release workflow.
+          gh release view "$TAG" >/dev/null 2>&1 || gh release create "$TAG" --generate-notes || true
 
       - name: Upload .deb to GitHub Release
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,10 @@ jobs:
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release create "${{ github.ref_name }}" --generate-notes
+          TAG: ${{ github.ref_name }}
+        # Idempotent: the deb/rpm workflows may have created the release first.
+        run: |
+          gh release view "$TAG" >/dev/null 2>&1 || gh release create "$TAG" --generate-notes
 
   notify-homebrew:
     name: Notify Homebrew Tap

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -141,7 +141,8 @@ jobs:
             sleep 30
           done
           echo "Release $TAG not found after 15 minutes, creating it"
-          gh release create "$TAG" --generate-notes
+          # Tolerate a race with the release workflow.
+          gh release view "$TAG" >/dev/null 2>&1 || gh release create "$TAG" --generate-notes || true
 
       - name: Upload RPM to GitHub Release
         if: startsWith(github.ref, 'refs/tags/')

--- a/speedtest_z/grafana.py
+++ b/speedtest_z/grafana.py
@@ -80,8 +80,23 @@ def encode_write_request(timeseries_list: list[bytes]) -> bytes:
     return data
 
 
+class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Refuse to follow HTTP redirects.
+
+    Prevents the ``Authorization`` header (and the metric payload) from being
+    forwarded to a redirect target.  A redirect from a Prometheus Remote Write
+    endpoint is anomalous, so it is surfaced as an :class:`~urllib.error.HTTPError`.
+    """
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # type: ignore[no-untyped-def]
+        return None
+
+
 class GrafanaSender:
     """Grafana Cloud Prometheus Remote Write sender."""
+
+    # A single push completes within seconds, so use a short cap to avoid hangs.
+    TIMEOUT = 30
 
     def __init__(self, url: str, username: str, token: str) -> None:
         """Initialize with Grafana Cloud credentials."""
@@ -139,10 +154,14 @@ class GrafanaSender:
         req.add_header("X-Prometheus-Remote-Write-Version", "0.1.0")
 
         credentials = base64.b64encode(f"{self.username}:{self.token}".encode()).decode()
-        req.add_header("Authorization", f"Basic {credentials}")
+        # An unredirected header is not forwarded on redirects, so the
+        # credentials never leak to a redirect target (defense in depth with
+        # the no-redirect opener below).
+        req.add_unredirected_header("Authorization", f"Basic {credentials}")
 
+        opener = urllib.request.build_opener(_NoRedirectHandler)
         try:
-            with urllib.request.urlopen(req) as resp:
+            with opener.open(req, timeout=self.TIMEOUT) as resp:
                 logger.info(f"Grafana push OK: {resp.status} {resp.reason}")
         except urllib.error.HTTPError as e:
             body = e.read().decode("utf-8", errors="replace")

--- a/speedtest_z/runner.py
+++ b/speedtest_z/runner.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import configparser
+import contextlib
 import logging
 import os
 import platform
@@ -135,13 +136,21 @@ class SpeedtestZ:
             self.action_chains = ActionChains(self.driver)
 
             if not self.headless:
-                self.driver.set_window_size(self.WINDOW_WIDTH, self.WINDOW_HEIGHT)
-                pos = self._get_window_position()
-                if pos:
-                    self.driver.set_window_position(*pos)
-                    logger.info(f"Window moved to Top-Right: {pos}")
+                # Window positioning is cosmetic; keep going if it fails.
+                try:
+                    self.driver.set_window_size(self.WINDOW_WIDTH, self.WINDOW_HEIGHT)
+                    pos = self._get_window_position()
+                    if pos:
+                        self.driver.set_window_position(*pos)
+                        logger.info(f"Window moved to Top-Right: {pos}")
+                except Exception as e:
+                    logger.warning(f"Window positioning failed: {e}")
 
         except Exception as e:
+            # Do not leak an already-started Chrome/chromedriver process.
+            if getattr(self, "driver", None):
+                with contextlib.suppress(Exception):
+                    self.driver.quit()
             logger.error(_msg("chrome_init_failed", error=str(e)))
             sys.exit(1)
 
@@ -167,10 +176,19 @@ class SpeedtestZ:
             return False
 
     def close(self) -> None:
-        """Close the browser and clean up."""
+        """Close the browser and clean up.
+
+        Idempotent: safe to call more than once (e.g. via both the SIGTERM
+        handler and the ``finally`` block in :func:`speedtest_z.cli.main`).
+        """
+        if getattr(self, "_closed", False):
+            return
+        self._closed = True
+
         if hasattr(self, "driver"):
             logger.info("Closing browser session...")
-            self.driver.quit()
+            with contextlib.suppress(Exception):
+                self.driver.quit()
         if hasattr(self, "sender"):
             self.sender.close()
         elif hasattr(self, "otel_sender") and self.otel_sender:

--- a/speedtest_z/sender.py
+++ b/speedtest_z/sender.py
@@ -40,6 +40,12 @@ class SenderManager:
             grafana_enable = config.getboolean("grafana", "enable", fallback=False)
             if grafana_enable:
                 try:
+                    # cramjam is an optional dependency ([grafana] extra).
+                    # GrafanaSender only imports it inside send(), so import it
+                    # explicitly here to detect a missing install at startup and
+                    # surface the install hint.
+                    import cramjam  # noqa: F401
+
                     from speedtest_z.grafana import GrafanaSender
 
                     url = config.get("grafana", "remote_write_url")
@@ -48,8 +54,6 @@ class SenderManager:
                     self.grafana_sender = GrafanaSender(url, username, token)
                 except ImportError:
                     logger.error("cramjam not installed. Run: pip install speedtest-z[grafana]")
-                except configparser.NoSectionError:
-                    logger.error("[grafana] section missing required keys")
                 except configparser.NoOptionError as e:
                     logger.error(f"[grafana] config incomplete: {e}")
 
@@ -79,6 +83,14 @@ class SenderManager:
     def send(self, data_list: list[dict[str, str]]) -> None:
         """Send measurement results to all enabled backends."""
         if not data_list:
+            return
+
+        # Drop empty values. Zabbix would accept an empty value as-is while
+        # Grafana/OTel silently skip it on float() failure; filtering here keeps
+        # what is sent consistent across all backends.
+        data_list = [item for item in data_list if str(item.get("value", "")).strip()]
+        if not data_list:
+            logger.debug("No non-empty metrics to send.")
             return
 
         packet = []

--- a/speedtest_z/sites/inonius.py
+++ b/speedtest_z/sites/inonius.py
@@ -17,27 +17,46 @@ logger = logging.getLogger("speedtest-z")
 
 URL = "https://inonius.net/speedtest/"
 
+# Download display elements (IPv4 / IPv6) used to detect progress: they show a
+# number once the test is actually running.
+_PROGRESS_XPATHS = (
+    "/html/body/div/astro-island/div/div[1]/div/div[1]/div[1]/div[1]/div/div/span[1]",  # IPv4_DL
+    "/html/body/div/astro-island/div/div[2]/div/div[1]/div[1]/div[1]/div/div/span[1]",  # IPv6_DL
+)
+
+
+def _inonius_is_running(driver) -> bool:  # type: ignore[no-untyped-def]
+    """Return True if a measurement value (a digit) is visible.
+
+    Mere presence of the page container does not mean the test started, so
+    this checks the download display elements for an actual numeric reading.
+    """
+    for xpath in _PROGRESS_XPATHS:
+        try:
+            if any(ch.isdigit() for ch in driver.find_element(By.XPATH, xpath).text):
+                return True
+        except NoSuchElementException:
+            continue
+    return False
+
 
 def _inonius_fallback_start(app: SpeedtestZ) -> bool:
-    """Attempt to start iNonius test when consent dialog was skipped.
+    """Detect an auto-started iNonius test when the consent dialog was skipped.
 
-    When cookies remember consent, the dialog may not appear and the test
-    may start automatically or require a manual start button click.
-    Returns True if the test appears to be running, False otherwise.
+    When cookies remember consent, the dialog may not appear and the test may
+    start automatically.  Instead of trusting that the page merely loaded, this
+    polls for an actual measurement value before declaring the test running, so
+    a page that did *not* auto-start fails fast (with a snapshot) rather than
+    falsely proceeding to a guaranteed completion-wait timeout.
+
+    Returns True if a measurement is progressing, False otherwise.
     """
     try:
-        # dialog なしでテストが自動開始されたか確認
-        # Download/Upload の数値やアニメーションが表示されていれば進行中
-        WebDriverWait(app.driver, 10).until(
-            lambda d: (
-                d.find_elements(By.CSS_SELECTOR, "astro-island > div")
-                and not d.find_elements(By.CSS_SELECTOR, "dialog[open]")
-            )
-        )
-        logger.info("inonius: Test already running (cookie consent)")
+        WebDriverWait(app.driver, 15).until(_inonius_is_running)
+        logger.info("inonius: Test is running (auto-started via cookie consent)")
         return True
     except TimeoutException:
-        logger.error("inonius: Could not start test (no dialog, no auto-start)")
+        logger.error("inonius: Could not start test (no dialog, no measurement progress)")
         app.take_snapshot("inonius_error_fallback")
         return False
 

--- a/speedtest_z/sites/inonius.py
+++ b/speedtest_z/sites/inonius.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from selenium.common.exceptions import NoSuchElementException, TimeoutException
+from selenium.common.exceptions import (
+    NoSuchElementException,
+    StaleElementReferenceException,
+    TimeoutException,
+)
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
@@ -35,7 +39,8 @@ def _inonius_is_running(driver) -> bool:  # type: ignore[no-untyped-def]
         try:
             if any(ch.isdigit() for ch in driver.find_element(By.XPATH, xpath).text):
                 return True
-        except NoSuchElementException:
+        except (NoSuchElementException, StaleElementReferenceException):
+            # Element absent or momentarily stale while polling: not yet running.
             continue
     return False
 

--- a/speedtest_z/sites/mlab.py
+++ b/speedtest_z/sites/mlab.py
@@ -75,16 +75,26 @@ def run_mlab(app: SpeedtestZ) -> None:
         base_xp = '//*[@id="measurementSpace"]//table/tbody'
 
         try:
+            # Take the first token safely to avoid IndexError on empty text.
+            def _first_token(text: str) -> str:
+                parts = text.split()
+                return parts[0] if parts else ""
+
             raw_dl = app.driver.find_element(By.XPATH, f"{base_xp}/tr[3]/td[3]/strong").text
-            download = raw_dl.split()[0]
+            download = _first_token(raw_dl)
             raw_ul = app.driver.find_element(By.XPATH, f"{base_xp}/tr[4]/td[3]/strong").text
-            upload = raw_ul.split()[0]
+            upload = _first_token(raw_ul)
             raw_lat = app.driver.find_element(By.XPATH, f"{base_xp}/tr[5]/td[3]/strong").text
-            latency = raw_lat.split()[0]
+            latency = _first_token(raw_lat)
             raw_retr = app.driver.find_element(By.XPATH, f"{base_xp}/tr[6]/td[3]/strong").text
             retrans = raw_retr.replace("%", "").strip()
 
             logger.debug(f"mlab Result: {download=} {upload=} {latency=} {retrans=}")
+
+            if not any(c.isdigit() for c in download):
+                logger.error("mlab: Invalid download value; skipping send.")
+                app.take_snapshot("mlab_error_parse")
+                return
 
             data = [
                 {

--- a/speedtest_z/sites/netflix.py
+++ b/speedtest_z/sites/netflix.py
@@ -61,6 +61,11 @@ def run_netflix(app: SpeedtestZ) -> None:
 
             logger.debug(f"netflix: Result: {download=} {upload=} {latency=} {server_locations=}")
 
+            if not any(c.isdigit() for c in download):
+                logger.error("netflix: Invalid download value; skipping send.")
+                app.take_snapshot("netflix_error_parse")
+                return
+
             data = [
                 {
                     "host": app.zabbix_host,

--- a/speedtest_z/sites/usen.py
+++ b/speedtest_z/sites/usen.py
@@ -73,6 +73,11 @@ def run_usen(app: SpeedtestZ) -> None:
 
             logger.debug(f"usen Result: {download=} {upload=} {ping=} {jitter=}")
 
+            if not any(c.isdigit() for c in download):
+                logger.error("usen: Invalid download value; skipping send.")
+                app.take_snapshot("usen_error_parse")
+                return
+
             data = [
                 {
                     "host": app.zabbix_host,

--- a/speedtest_z/sites/usen.py
+++ b/speedtest_z/sites/usen.py
@@ -43,7 +43,8 @@ def run_usen(app: SpeedtestZ) -> None:
         try:
             WebDriverWait(app.driver, 10).until(
                 lambda d: (
-                    "speedtest_wait" in d.find_element(By.TAG_NAME, "body").get_attribute("class")
+                    "speedtest_wait"
+                    in (d.find_element(By.TAG_NAME, "body").get_attribute("class") or "")
                 )
             )
             logger.info("usen: Measuring... (speedtest_wait class detected)")
@@ -55,7 +56,7 @@ def run_usen(app: SpeedtestZ) -> None:
             WebDriverWait(app.driver, 120).until(
                 lambda d: (
                     "speedtest_wait"
-                    not in d.find_element(By.TAG_NAME, "body").get_attribute("class")
+                    not in (d.find_element(By.TAG_NAME, "body").get_attribute("class") or "")
                 )
             )
             time.sleep(2)

--- a/tests/test_grafana.py
+++ b/tests/test_grafana.py
@@ -1,8 +1,12 @@
 """Grafana Cloud 統合のテスト"""
 
 import configparser
+import io
 import struct
+import urllib.error
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from speedtest_z.grafana import (
     GrafanaSender,
@@ -18,6 +22,74 @@ from speedtest_z.grafana import (
 )
 from speedtest_z.runner import SpeedtestZ
 from speedtest_z.sender import SenderManager
+
+# --- Protobuf decoder (test-only, for round-trip verification) ---
+
+
+def _decode_varint(data, i):
+    """Decode a protobuf varint starting at offset *i*; return (value, next_offset)."""
+    result = 0
+    shift = 0
+    while True:
+        b = data[i]
+        i += 1
+        result |= (b & 0x7F) << shift
+        if not (b & 0x80):
+            break
+        shift += 7
+    return result, i
+
+
+def _decode_fields(data):
+    """Decode a protobuf message into a list of (field_number, wire_type, value)."""
+    fields = []
+    i = 0
+    while i < len(data):
+        tag, i = _decode_varint(data, i)
+        field, wire = tag >> 3, tag & 7
+        if wire == 0:  # varint
+            val, i = _decode_varint(data, i)
+        elif wire == 1:  # 64-bit
+            val, i = data[i : i + 8], i + 8
+        elif wire == 2:  # length-delimited
+            length, i = _decode_varint(data, i)
+            val, i = data[i : i + length], i + length
+        elif wire == 5:  # 32-bit
+            val, i = data[i : i + 4], i + 4
+        else:
+            raise ValueError(f"unsupported wire type {wire}")
+        fields.append((field, wire, val))
+    return fields
+
+
+def _decode_write_request(data):
+    """Decode a Prometheus WriteRequest into a list of {labels, samples} dicts."""
+    series = []
+    for field, wire, val in _decode_fields(data):
+        if field != 1 or wire != 2:  # TimeSeries
+            continue
+        labels = {}
+        samples = []
+        for f2, w2, v2 in _decode_fields(val):
+            if f2 == 1 and w2 == 2:  # Label
+                name = value = None
+                for f3, _w3, v3 in _decode_fields(v2):
+                    if f3 == 1:
+                        name = v3.decode("utf-8")
+                    elif f3 == 2:
+                        value = v3.decode("utf-8")
+                labels[name] = value
+            elif f2 == 2 and w2 == 2:  # Sample
+                s_value = s_ts = None
+                for f3, w3, v3 in _decode_fields(v2):
+                    if f3 == 1 and w3 == 1:
+                        s_value = struct.unpack("<d", v3)[0]
+                    elif f3 == 2 and w3 == 0:
+                        s_ts = v3
+                samples.append((s_value, s_ts))
+        series.append({"labels": labels, "samples": samples})
+    return series
+
 
 # --- Protobuf エンコーダーのユニットテスト ---
 
@@ -116,6 +188,46 @@ class TestEncodeWriteRequest:
         assert b"speedtest_upload" in result
 
 
+class TestEncoderRoundTrip:
+    """Decode the encoded output and assert the structure/values exactly.
+
+    Substring containment checks cannot detect swapped field numbers or a
+    corrupted double/varint, so round-trip decoding verifies value equality.
+    """
+
+    def test_single_series_round_trip(self):
+        labels = [
+            ("__name__", "speedtest_download"),
+            ("site", "cloudflare"),
+            ("host", "host-1"),
+        ]
+        ts = encode_timeseries(labels, 100.5, 1700000000000)
+        series = _decode_write_request(encode_write_request([ts]))
+
+        assert len(series) == 1
+        assert series[0]["labels"] == {
+            "__name__": "speedtest_download",
+            "site": "cloudflare",
+            "host": "host-1",
+        }
+        assert len(series[0]["samples"]) == 1
+        value, ts_ms = series[0]["samples"][0]
+        assert abs(value - 100.5) < 1e-9
+        assert ts_ms == 1700000000000
+
+    def test_multiple_series_round_trip(self):
+        ts1 = encode_timeseries([("__name__", "speedtest_download")], 100.5, 1700000000000)
+        ts2 = encode_timeseries([("__name__", "speedtest_upload")], 50.25, 1700000000001)
+        series = _decode_write_request(encode_write_request([ts1, ts2]))
+
+        assert len(series) == 2
+        assert series[0]["labels"]["__name__"] == "speedtest_download"
+        assert abs(series[0]["samples"][0][0] - 100.5) < 1e-9
+        assert series[1]["labels"]["__name__"] == "speedtest_upload"
+        assert abs(series[1]["samples"][0][0] - 50.25) < 1e-9
+        assert series[1]["samples"][0][1] == 1700000000001
+
+
 # --- GrafanaSender のテスト ---
 
 
@@ -135,6 +247,17 @@ class TestGrafanaSender:
         mock_cramjam.snappy.compress_raw.return_value = b"compressed"
         return mock_cramjam
 
+    def _mock_opener(self, status=200, reason="OK"):
+        """Return a mock opener (as build_opener does) whose open() succeeds."""
+        mock_resp = MagicMock()
+        mock_resp.status = status
+        mock_resp.reason = reason
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_opener = MagicMock()
+        mock_opener.open.return_value = mock_resp
+        return mock_opener
+
     def test_send_numeric_values(self):
         """数値メトリクスが送信されること"""
         sender = GrafanaSender("https://example.com/push", "user", "token")
@@ -142,25 +265,21 @@ class TestGrafanaSender:
             {"key": "cloudflare.download", "value": "100.5", "host": "test-host"},
             {"key": "cloudflare.upload", "value": "50.2", "host": "test-host"},
         ]
+        mock_opener = self._mock_opener()
         with (
-            patch("speedtest_z.grafana.urllib.request.urlopen") as mock_urlopen,
+            patch("speedtest_z.grafana.urllib.request.build_opener", return_value=mock_opener),
             patch.dict("sys.modules", {"cramjam": self._mock_cramjam()}),
         ):
-            mock_resp = MagicMock()
-            mock_resp.status = 200
-            mock_resp.reason = "OK"
-            mock_resp.__enter__ = lambda s: s
-            mock_resp.__exit__ = MagicMock(return_value=False)
-            mock_urlopen.return_value = mock_resp
-
             sender.send(data)
-            mock_urlopen.assert_called_once()
+            mock_opener.open.assert_called_once()
 
             # HTTP リクエストの検証
-            req = mock_urlopen.call_args[0][0]
+            req = mock_opener.open.call_args[0][0]
             assert req.get_header("Content-type") == "application/x-protobuf"
             assert req.get_header("Content-encoding") == "snappy"
+            # Authorization goes in an unredirected header (not forwarded on redirect)
             assert "Basic" in req.get_header("Authorization")
+            assert "Authorization" in req.unredirected_hdrs
 
     def test_send_skips_non_numeric(self):
         """数値でない値はスキップされること"""
@@ -169,24 +288,26 @@ class TestGrafanaSender:
             {"key": "netflix.server-locations", "value": "Tokyo, Osaka"},
             {"key": "boxtest.POP", "value": "NRT"},
         ]
+        mock_opener = self._mock_opener()
         with (
             patch.dict("sys.modules", {"cramjam": self._mock_cramjam()}),
-            patch("speedtest_z.grafana.urllib.request.urlopen") as mock_urlopen,
+            patch("speedtest_z.grafana.urllib.request.build_opener", return_value=mock_opener),
         ):
             sender.send(data)
-            # 全て非数値なので送信されない
-            mock_urlopen.assert_not_called()
+            # All non-numeric, so nothing is sent
+            mock_opener.open.assert_not_called()
 
     def test_send_skips_invalid_key(self):
         """ドットなしの key はスキップされること"""
         sender = GrafanaSender("https://example.com/push", "user", "token")
         data = [{"key": "invalid_key", "value": "100.5"}]
+        mock_opener = self._mock_opener()
         with (
             patch.dict("sys.modules", {"cramjam": self._mock_cramjam()}),
-            patch("speedtest_z.grafana.urllib.request.urlopen") as mock_urlopen,
+            patch("speedtest_z.grafana.urllib.request.build_opener", return_value=mock_opener),
         ):
             sender.send(data)
-            mock_urlopen.assert_not_called()
+            mock_opener.open.assert_not_called()
 
     def test_send_mixed_values(self):
         """数値と非数値が混在する場合、数値のみ送信されること"""
@@ -195,19 +316,54 @@ class TestGrafanaSender:
             {"key": "cloudflare.download", "value": "100.5", "host": "test"},
             {"key": "netflix.server-locations", "value": "Tokyo"},
         ]
+        mock_opener = self._mock_opener()
         with (
-            patch("speedtest_z.grafana.urllib.request.urlopen") as mock_urlopen,
+            patch("speedtest_z.grafana.urllib.request.build_opener", return_value=mock_opener),
             patch.dict("sys.modules", {"cramjam": self._mock_cramjam()}),
         ):
-            mock_resp = MagicMock()
-            mock_resp.status = 200
-            mock_resp.reason = "OK"
-            mock_resp.__enter__ = lambda s: s
-            mock_resp.__exit__ = MagicMock(return_value=False)
-            mock_urlopen.return_value = mock_resp
-
             sender.send(data)
-            mock_urlopen.assert_called_once()
+            mock_opener.open.assert_called_once()
+
+    def test_send_payload_round_trip(self):
+        """The payload passed to compress_raw carries the correct labels/value."""
+        sender = GrafanaSender("https://example.com/push", "user", "token")
+        data = [
+            {"key": "cloudflare.download", "value": "100.5", "host": "test-host"},
+            {"key": "netflix.server-locations", "value": "Tokyo"},  # non-numeric -> skipped
+        ]
+        mock_cramjam = self._mock_cramjam()
+        mock_opener = self._mock_opener()
+        with (
+            patch("speedtest_z.grafana.urllib.request.build_opener", return_value=mock_opener),
+            patch.dict("sys.modules", {"cramjam": mock_cramjam}),
+        ):
+            sender.send(data)
+
+        # Decode the actual WriteRequest that was handed to compress_raw
+        raw = mock_cramjam.snappy.compress_raw.call_args[0][0]
+        series = _decode_write_request(bytes(raw))
+        assert len(series) == 1  # the non-numeric item is skipped
+        labels = series[0]["labels"]
+        assert labels["__name__"] == "speedtest_download"
+        assert labels["site"] == "cloudflare"
+        assert labels["host"] == "test-host"
+        value, _ts = series[0]["samples"][0]
+        assert abs(value - 100.5) < 1e-9
+
+    def test_send_does_not_follow_redirect(self):
+        """A redirect is not followed and is re-raised as failure (no credential leak)."""
+        sender = GrafanaSender("https://example.com/push", "user", "token")
+        data = [{"key": "cloudflare.download", "value": "100.5", "host": "h"}]
+        mock_opener = MagicMock()
+        mock_opener.open.side_effect = urllib.error.HTTPError(
+            "https://evil.example.com/", 302, "Found", {}, io.BytesIO(b"redirected")
+        )
+        with (
+            patch("speedtest_z.grafana.urllib.request.build_opener", return_value=mock_opener),
+            patch.dict("sys.modules", {"cramjam": self._mock_cramjam()}),
+            pytest.raises(urllib.error.HTTPError),
+        ):
+            sender.send(data)
 
 
 # --- cramjam 未インストール時のフォールバックテスト ---
@@ -387,3 +543,151 @@ class TestDryRunCompat:
         """どちらもない場合、デフォルト True になること"""
         app = self._make_app_with_config({"general": {"headless": "true"}})
         assert app.dryrun is True
+
+
+# --- SenderManager.__init__ real-branch tests ---
+
+
+class TestSenderManagerInit:
+    """Exercise the real Grafana/OTel init branches of SenderManager.__init__.
+
+    Earlier tests patched __init__ and set attributes by hand, so the enable
+    checks, header parsing, and missing-dependency handling never ran.
+    """
+
+    @staticmethod
+    def _config(sections):
+        config = configparser.ConfigParser()
+        config.read_dict(sections)
+        return config
+
+    def test_grafana_disabled_no_sender(self):
+        """enable=false keeps grafana_sender None even if the section exists."""
+        config = self._config(
+            {
+                "zabbix": {"host": "h"},
+                "grafana": {
+                    "enable": "false",
+                    "remote_write_url": "u",
+                    "username": "x",
+                    "token": "t",
+                },
+            }
+        )
+        sm = SenderManager(config, "h", dry_run=True)
+        assert sm.grafana_sender is None
+
+    def test_grafana_enabled_constructs_sender(self):
+        """enable=true with cramjam present constructs a GrafanaSender."""
+        config = self._config(
+            {
+                "zabbix": {"host": "h"},
+                "grafana": {
+                    "enable": "true",
+                    "remote_write_url": "https://example.com/push",
+                    "username": "x",
+                    "token": "t",
+                },
+            }
+        )
+        with (
+            patch.dict("sys.modules", {"cramjam": MagicMock()}),
+            patch("speedtest_z.grafana.GrafanaSender") as mock_gs,
+        ):
+            sm = SenderManager(config, "h", dry_run=True)
+        mock_gs.assert_called_once_with("https://example.com/push", "x", "t")
+        assert sm.grafana_sender is mock_gs.return_value
+
+    def test_grafana_missing_cramjam_logs_and_none(self):
+        """A missing cramjam is caught (ImportError) and grafana_sender stays None."""
+        config = self._config(
+            {
+                "zabbix": {"host": "h"},
+                "grafana": {
+                    "enable": "true",
+                    "remote_write_url": "https://example.com/push",
+                    "username": "x",
+                    "token": "t",
+                },
+            }
+        )
+        # sys.modules["cramjam"] = None makes `import cramjam` raise ImportError
+        with patch.dict("sys.modules", {"cramjam": None}):
+            sm = SenderManager(config, "h", dry_run=True)
+        assert sm.grafana_sender is None
+
+    def test_grafana_incomplete_config_none(self):
+        """A missing required key (NoOptionError) keeps grafana_sender None."""
+        config = self._config(
+            {
+                "zabbix": {"host": "h"},
+                "grafana": {"enable": "true", "remote_write_url": "https://example.com/push"},
+            }
+        )
+        with patch.dict("sys.modules", {"cramjam": MagicMock()}):
+            sm = SenderManager(config, "h", dry_run=True)
+        assert sm.grafana_sender is None
+
+    def test_otel_headers_parsed(self):
+        """'K1=V1, K2 = V2' headers are parsed into a dict and passed to OtelSender."""
+        config = self._config(
+            {
+                "zabbix": {"host": "h"},
+                "otel": {
+                    "enable": "true",
+                    "endpoint": "https://otlp.example.com/",
+                    "headers": "Api-Key=k, X-Scope-OrgID = 1",
+                },
+            }
+        )
+        # Substitute speedtest_z.otel so this works without opentelemetry installed
+        fake_otel = MagicMock()
+        with patch.dict("sys.modules", {"speedtest_z.otel": fake_otel}):
+            sm = SenderManager(config, "myhost", dry_run=True)
+        fake_otel.OtelSender.assert_called_once_with(
+            "https://otlp.example.com/", {"Api-Key": "k", "X-Scope-OrgID": "1"}, "myhost"
+        )
+        assert sm.otel_sender is fake_otel.OtelSender.return_value
+
+    def test_otel_disabled_no_sender(self):
+        """enable=false keeps otel_sender None."""
+        config = self._config(
+            {
+                "zabbix": {"host": "h"},
+                "otel": {"enable": "false", "endpoint": "https://otlp.example.com/"},
+            }
+        )
+        sm = SenderManager(config, "h", dry_run=True)
+        assert sm.otel_sender is None
+
+
+# --- Empty-value filter tests ---
+
+
+class TestSendEmptyFilter:
+    """Empty values are not sent to any backend (cross-backend consistency)."""
+
+    def test_empty_values_dropped(self):
+        mock_grafana = MagicMock()
+        sender = _make_sender(dryrun=False, zabbix_enable=True, grafana_sender=mock_grafana)
+        data = [
+            {"key": "cloudflare.download", "value": "100.5", "host": "h"},
+            {"key": "cloudflare.upload", "value": "", "host": "h"},  # empty -> dropped
+        ]
+        with patch("speedtest_z.sender.Sender") as mock_sender_cls:
+            mock_sender_cls.return_value = MagicMock()
+            sender.send(data)
+        sent = mock_grafana.send.call_args[0][0]
+        assert len(sent) == 1
+        assert sent[0]["key"] == "cloudflare.download"
+
+    def test_all_empty_no_send(self):
+        mock_grafana = MagicMock()
+        sender = _make_sender(dryrun=False, zabbix_enable=True, grafana_sender=mock_grafana)
+        data = [{"key": "cloudflare.download", "value": "", "host": "h"}]
+        with patch("speedtest_z.sender.Sender") as mock_sender_cls:
+            mock_instance = MagicMock()
+            mock_sender_cls.return_value = mock_instance
+            sender.send(data)
+        mock_instance.send_bulk.assert_not_called()
+        mock_grafana.send.assert_not_called()

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -467,6 +467,21 @@ class TestClose:
         app.close()  # should not raise
         app.driver.quit.assert_called_once()
 
+    def test_close_is_idempotent(self):
+        """Calling close() twice quits the driver only once (SIGTERM + finally)."""
+        app = _make_app()
+        app.close()
+        app.close()
+        app.driver.quit.assert_called_once()
+        app.sender.close.assert_called_once()
+
+    def test_close_survives_driver_quit_error(self):
+        """A driver.quit() error is suppressed so sender.close() still runs."""
+        app = _make_app()
+        app.driver.quit.side_effect = Exception("session already closed")
+        app.close()  # should not raise
+        app.sender.close.assert_called_once()
+
 
 class TestSenderManagerClose:
     """Tests for SenderManager.close() cleanup logic."""

--- a/tests/test_sites/test_inonius.py
+++ b/tests/test_sites/test_inonius.py
@@ -4,7 +4,34 @@ from unittest.mock import MagicMock, patch
 
 from selenium.common.exceptions import NoSuchElementException, TimeoutException
 
-from speedtest_z.sites.inonius import _inonius_fallback_start, run_inonius
+from speedtest_z.sites.inonius import (
+    _inonius_fallback_start,
+    _inonius_is_running,
+    run_inonius,
+)
+
+
+class TestInoniusIsRunning:
+    """Tests for _inonius_is_running() progress detection."""
+
+    def test_true_when_digit_present(self, mock_app):
+        """A measurement value (digit) means the test is running."""
+        el = MagicMock()
+        el.text = "123"
+        mock_app.driver.find_element.return_value = el
+        assert _inonius_is_running(mock_app.driver) is True
+
+    def test_false_when_no_digit(self, mock_app):
+        """Empty/no-digit text means the test has not started."""
+        el = MagicMock()
+        el.text = ""
+        mock_app.driver.find_element.return_value = el
+        assert _inonius_is_running(mock_app.driver) is False
+
+    def test_false_when_elements_missing(self, mock_app):
+        """Missing progress elements mean the test is not running."""
+        mock_app.driver.find_element.side_effect = NoSuchElementException("nope")
+        assert _inonius_is_running(mock_app.driver) is False
 
 
 class TestInoniusFallbackStart:

--- a/tests/test_sites/test_inonius.py
+++ b/tests/test_sites/test_inonius.py
@@ -2,7 +2,11 @@
 
 from unittest.mock import MagicMock, patch
 
-from selenium.common.exceptions import NoSuchElementException, TimeoutException
+from selenium.common.exceptions import (
+    NoSuchElementException,
+    StaleElementReferenceException,
+    TimeoutException,
+)
 
 from speedtest_z.sites.inonius import (
     _inonius_fallback_start,
@@ -31,6 +35,11 @@ class TestInoniusIsRunning:
     def test_false_when_elements_missing(self, mock_app):
         """Missing progress elements mean the test is not running."""
         mock_app.driver.find_element.side_effect = NoSuchElementException("nope")
+        assert _inonius_is_running(mock_app.driver) is False
+
+    def test_false_when_elements_stale(self, mock_app):
+        """A stale element while polling is treated as not-yet-running, not an error."""
+        mock_app.driver.find_element.side_effect = StaleElementReferenceException("stale")
         assert _inonius_is_running(mock_app.driver) is False
 
 

--- a/tests/test_sites/test_mlab.py
+++ b/tests/test_sites/test_mlab.py
@@ -182,6 +182,41 @@ class TestRunMlab:
 
         mock_app.take_snapshot.assert_any_call("mlab")
 
+    def test_invalid_download_skips_send(self, mock_app):
+        """Skip send and snapshot when the download value has no digit."""
+        mock_app._should_run = MagicMock(return_value=True)
+        mock_app._load_with_retry = MagicMock(return_value=True)
+        mock_app.auto_consent = True
+        mock_app.send_results = MagicMock()
+        mock_app.take_snapshot = MagicMock()
+        mock_app.driver.find_element.side_effect = _mock_find_element_results(download="")
+
+        with patch("speedtest_z.sites.mlab.WebDriverWait") as mock_wdw:
+            mock_app.wait.until.side_effect = [MagicMock(), MagicMock()]
+            mock_wdw.return_value.until.return_value = True
+            run_mlab(mock_app)
+
+        mock_app.send_results.assert_not_called()
+        mock_app.take_snapshot.assert_any_call("mlab_error_parse")
+
+    def test_empty_download_does_not_raise(self, mock_app):
+        """Empty result text is handled without IndexError from split()."""
+        mock_app._should_run = MagicMock(return_value=True)
+        mock_app._load_with_retry = MagicMock(return_value=True)
+        mock_app.auto_consent = True
+        mock_app.send_results = MagicMock()
+        mock_app.take_snapshot = MagicMock()
+        mock_app.driver.find_element.side_effect = _mock_find_element_results(
+            download="", upload="", latency="", retrans=""
+        )
+
+        with patch("speedtest_z.sites.mlab.WebDriverWait") as mock_wdw:
+            mock_app.wait.until.side_effect = [MagicMock(), MagicMock()]
+            mock_wdw.return_value.until.return_value = True
+            run_mlab(mock_app)  # must not raise IndexError
+
+        mock_app.send_results.assert_not_called()
+
     def test_manual_consent_mode(self, mock_app):
         """In manual consent mode, wait for user to check the checkbox."""
         mock_app._should_run = MagicMock(return_value=True)

--- a/tests/test_sites/test_netflix.py
+++ b/tests/test_sites/test_netflix.py
@@ -183,3 +183,22 @@ class TestRunNetflix:
         data = mock_app.send_results.call_args[0][0]
         for item in data:
             assert item["host"] == "custom-host"
+
+    def test_invalid_download_skips_send(self, mock_app):
+        """Skip send and snapshot when the download value has no digit."""
+        mock_app._should_run = MagicMock(return_value=True)
+        mock_app._load_with_retry = MagicMock(return_value=True)
+        mock_app.send_results = MagicMock()
+        mock_app.take_snapshot = MagicMock()
+        mock_app.driver.find_element.side_effect = _mock_find_element_results(download="")
+
+        with (
+            patch("speedtest_z.sites.netflix.WebDriverWait") as mock_wdw,
+            patch("speedtest_z.sites.netflix.time"),
+        ):
+            mock_app.wait.until.return_value = MagicMock()
+            mock_wdw.return_value.until.return_value = True
+            run_netflix(mock_app)
+
+        mock_app.send_results.assert_not_called()
+        mock_app.take_snapshot.assert_any_call("netflix_error_parse")

--- a/tests/test_sites/test_usen.py
+++ b/tests/test_sites/test_usen.py
@@ -187,3 +187,22 @@ class TestRunUsen:
         data = mock_app.send_results.call_args[0][0]
         for item in data:
             assert item["host"] == "usen-host"
+
+    def test_invalid_download_skips_send(self, mock_app):
+        """Skip send and snapshot when the download value has no digit."""
+        mock_app._should_run = MagicMock(return_value=True)
+        mock_app._load_with_retry = MagicMock(return_value=True)
+        mock_app.send_results = MagicMock()
+        mock_app.take_snapshot = MagicMock()
+        mock_app.driver.find_element.side_effect = _mock_find_element_results(download="")
+
+        with (
+            patch("speedtest_z.sites.usen.WebDriverWait") as mock_wdw,
+            patch("speedtest_z.sites.usen.time"),
+        ):
+            mock_app.wait.until.return_value = MagicMock()
+            mock_wdw.return_value.until.return_value = True
+            run_usen(mock_app)
+
+        mock_app.send_results.assert_not_called()
+        mock_app.take_snapshot.assert_any_call("usen_error_parse")


### PR DESCRIPTION
## Summary

Addresses the 8 priority (medium-severity, verified) findings from a full-branch code review. All findings were independently confirmed against the code before fixing. No behavioral change to the happy path; the fixes harden error/edge handling and close a credential-leak vector.

## Fixes

1. **Grafana credential leakage on redirect** (`grafana.py`) — `urllib` followed redirects and re-sent the `Authorization` header to the redirect target. Credentials now use an *unredirected* header and a no-redirect opener refuses redirects (treated as a failed push). Also adds a 30s request timeout to avoid hangs.
2. **Dead cramjam install hint** (`sender.py`) — `GrafanaSender` only imports `cramjam` inside `send()`, so the startup `except ImportError` hint never fired. `SenderManager` now imports `cramjam` explicitly so a missing `[grafana]` extra is reported at startup. Removed the unreachable `NoSectionError` branch.
3. **Chrome process leak** (`runner._init_driver`) — on a post-launch init failure the driver was abandoned without `quit()`. Now quits before `sys.exit(1)`; cosmetic window positioning is non-fatal.
4. **iNonius consent fallback** (`inonius.py`) — the fallback declared the test "running" based on page presence alone, causing a guaranteed 90s timeout when the test had not auto-started. It now polls for an actual measurement value (fail-fast with snapshot otherwise).
5. **Idempotent `close()`** (`runner.py`) — SIGTERM handler + `finally` could double-`quit()` the driver and double-shutdown OTel. `close()` is now idempotent and tolerates a `quit()` error.
6. **Metric value validation** — empty values are dropped centrally in `SenderManager.send()` (Zabbix vs Grafana/OTel consistency); `netflix`/`usen`/`mlab` guard the primary download value, and M-Lab token extraction is safe against empty text.
7. **Release workflow race** (`release/deb/rpm.yml`) — `gh release create` is now idempotent (`view || create [|| true]`) so the parallel deb (jammy/noble) and release jobs cannot fail on "release already exists".

## Tests

- Protobuf encoder **round-trip** decoding (catches swapped fields / corrupted double/varint).
- `GrafanaSender.send()` **payload** verification (decodes what is handed to `compress_raw`).
- Redirect-rejection test for the credential fix.
- Real `SenderManager.__init__` branch coverage (header parsing, enable flags, missing-dependency handling) — previously these branches never ran.
- Regression tests for `close()` idempotency, the per-site download guards, M-Lab empty-text safety, and iNonius progress detection.

`ruff check` / `ruff format --check` / `mypy` clean; **301 passed, 9 skipped** (was 280). Comments and docstrings are in English (public repo).

## Notes / out of scope

- The lower-severity findings (DEFAULT_TIMEOUT dead constant, `err_` substring match, `main()` exit code, SHA-pinning Actions, dependency pinning, etc.) are intentionally left for follow-up PRs.
- The iNonius fix makes the fallback honest (fail fast) but cannot guarantee the manual-start case without live-site DOM access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)