### PR TITLE
fix: low-severity robustness and hygiene cleanups

### DIFF
--- a/speedtest_z/cli.py
+++ b/speedtest_z/cli.py
@@ -211,6 +211,9 @@ def main() -> None:
     if output_fmt in ("json", "csv"):
         from speedtest_z.output import OutputCollector
 
+        # Release the SenderManager's backends (e.g. the OTel exporter thread)
+        # before replacing it, so they do not leak for the rest of the run.
+        app.sender.close()
         app.sender = OutputCollector(output_fmt)
 
     try:

--- a/speedtest_z/config.py
+++ b/speedtest_z/config.py
@@ -30,7 +30,9 @@ def _find_config(name: str, cli_path: str | None = None) -> str | None:
     if os.path.isfile(name):
         return name
 
-    xdg = os.environ.get("XDG_CONFIG_HOME", os.path.expanduser("~/.config"))
+    # Use `or` so an empty XDG_CONFIG_HOME falls back to ~/.config (os.environ.get
+    # returns "" when the variable is set but empty, which would yield a relative path).
+    xdg = os.environ.get("XDG_CONFIG_HOME") or os.path.expanduser("~/.config")
     xdg_path = os.path.join(xdg, "speedtest-z", name)
     if os.path.isfile(xdg_path):
         return xdg_path

--- a/speedtest_z/healthcheck.py
+++ b/speedtest_z/healthcheck.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import urllib.error
 import urllib.request
 
 from speedtest_z.sites.boxtest import URL as BOXTEST_URL
@@ -55,7 +56,9 @@ def check_sites(sites: list[str] | None = None) -> int:
         label = "OK" if ok else "FAIL"
         if not ok:
             has_failure = True
-        print(f"  {site:<12}  {status}  {label}")
+            print(f"  {site:<12}  {status}  {label}  {reason}")
+        else:
+            print(f"  {site:<12}  {status}  {label}")
 
     return 1 if has_failure else 0
 
@@ -74,8 +77,10 @@ def _check_url(url: str, timeout: int = 10) -> tuple[int, str]:
             with urllib.request.urlopen(req, timeout=timeout) as resp:
                 return (resp.status, resp.reason)
         except urllib.error.HTTPError as e:
-            if e.code == 405 and method == "HEAD":
-                continue  # HEAD 不可 → GET フォールバック
+            # Some servers reject HEAD with 405 (Method Not Allowed) or
+            # 501 (Not Implemented); fall back to GET in both cases.
+            if e.code in (405, 501) and method == "HEAD":
+                continue
             return (e.code, str(e.reason))
         except Exception as e:
             return (0, str(e))

--- a/speedtest_z/runner.py
+++ b/speedtest_z/runner.py
@@ -93,8 +93,8 @@ class SpeedtestZ:
         # [snapshot]
         self.snapshot_enable = self.config.getboolean("snapshot", "enable", fallback=False)
         self.snapshot_dir = self.config.get("snapshot", "save_dir", fallback="./snapshots")
-        if self.snapshot_enable and not os.path.exists(self.snapshot_dir):
-            os.makedirs(self.snapshot_dir)
+        if self.snapshot_enable:
+            os.makedirs(self.snapshot_dir, exist_ok=True)
 
         # WebDriver の初期化
         self._init_driver()

--- a/speedtest_z/sender.py
+++ b/speedtest_z/sender.py
@@ -10,6 +10,17 @@ from zappix.sender import Sender, SenderData
 logger = logging.getLogger("speedtest-z")
 
 
+def _is_plaintext_remote(url: str) -> bool:
+    """Return True if *url* sends over plaintext http to a non-local host.
+
+    Local endpoints (a co-located OTLP collector or Prometheus) over http are a
+    common, low-risk setup, so they are not flagged.
+    """
+    if url.startswith("https://"):
+        return False
+    return not any(host in url for host in ("localhost", "127.0.0.1", "[::1]"))
+
+
 class SenderManager:
     """Manages all metric backends (Zabbix, Grafana, OTel)."""
 
@@ -51,7 +62,7 @@ class SenderManager:
                     url = config.get("grafana", "remote_write_url")
                     username = config.get("grafana", "username")
                     token = config.get("grafana", "token")
-                    if not url.startswith("https://"):
+                    if _is_plaintext_remote(url):
                         logger.warning(
                             "[grafana] remote_write_url is not https; "
                             "credentials would be sent over plaintext"
@@ -71,7 +82,7 @@ class SenderManager:
                     from speedtest_z.otel import OtelSender
 
                     endpoint = config.get("otel", "endpoint")
-                    if not endpoint.startswith("https://"):
+                    if _is_plaintext_remote(endpoint):
                         logger.warning(
                             "[otel] endpoint is not https; "
                             "headers (e.g. auth) would be sent over plaintext"

--- a/speedtest_z/sender.py
+++ b/speedtest_z/sender.py
@@ -51,6 +51,11 @@ class SenderManager:
                     url = config.get("grafana", "remote_write_url")
                     username = config.get("grafana", "username")
                     token = config.get("grafana", "token")
+                    if not url.startswith("https://"):
+                        logger.warning(
+                            "[grafana] remote_write_url is not https; "
+                            "credentials would be sent over plaintext"
+                        )
                     self.grafana_sender = GrafanaSender(url, username, token)
                 except ImportError:
                     logger.error("cramjam not installed. Run: pip install speedtest-z[grafana]")
@@ -66,6 +71,11 @@ class SenderManager:
                     from speedtest_z.otel import OtelSender
 
                     endpoint = config.get("otel", "endpoint")
+                    if not endpoint.startswith("https://"):
+                        logger.warning(
+                            "[otel] endpoint is not https; "
+                            "headers (e.g. auth) would be sent over plaintext"
+                        )
                     headers_str = config.get("otel", "headers", fallback="")
                     # "Key1=Val1,Key2=Val2" -> dict
                     headers: dict[str, str] = {}

--- a/speedtest_z/sites/boxtest.py
+++ b/speedtest_z/sites/boxtest.py
@@ -145,7 +145,9 @@ def run_boxtest(app: SpeedtestZ) -> None:
         for key_suffix, xpath in numeric_items.items():
             try:
                 val = app.driver.find_element(By.XPATH, xpath).text
-                clean_val = val.replace("Avg:", "").replace("ms", "").strip().split()[0]
+                # Take the first token safely to avoid IndexError on empty text.
+                tokens = val.replace("Avg:", "").replace("ms", "").strip().split()
+                clean_val = tokens[0] if tokens else ""
                 data.append(
                     {
                         "host": app.zabbix_host,
@@ -160,9 +162,10 @@ def run_boxtest(app: SpeedtestZ) -> None:
 
         logger.debug(f"boxtest Result: {data}")
         app.send_results(data)
-        app.take_snapshot("boxtest")
 
     except Exception as e:
         logger.error(f"boxtest Error: {e}")
     finally:
-        app.take_snapshot("boxtest_final")
+        # Single snapshot in finally (consistent with the other site runners),
+        # so a snapshot is captured on early return too.
+        app.take_snapshot("boxtest")

--- a/speedtest_z/sites/cloudflare.py
+++ b/speedtest_z/sites/cloudflare.py
@@ -70,8 +70,10 @@ def _extract_by_label(
                 return f"{value:.3f}"
             return f"{value}"
 
-    except (NoSuchElementException, Exception) as e:
-        logger.debug(f"cloudflare: Failed to extract '{label_text}': {e}")
+    except NoSuchElementException as e:
+        logger.debug(f"cloudflare: label '{label_text}' not found: {e}")
+    except Exception as e:
+        logger.warning(f"cloudflare: Unexpected error extracting '{label_text}': {e}")
     return ""
 
 

--- a/speedtest_z/sites/inonius.py
+++ b/speedtest_z/sites/inonius.py
@@ -138,7 +138,9 @@ def run_inonius(app: SpeedtestZ) -> None:
             try:
                 val = app.driver.find_element(By.XPATH, xpath).text
                 if key_suffix.endswith("_MSS"):
-                    val = val.split()[-1]
+                    # Take the last token safely to avoid IndexError on empty text.
+                    tokens = val.split()
+                    val = tokens[-1] if tokens else ""
                 if val:
                     full_key = f"inonius.{key_suffix}"
                     data.append(

--- a/speedtest_z/types.py
+++ b/speedtest_z/types.py
@@ -2,15 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Protocol, TypedDict
-
-
-class ZabbixItem(TypedDict):
-    """A single Zabbix trapper item."""
-
-    host: str
-    key: str
-    value: str
+from typing import Protocol
 
 
 class MetricSender(Protocol):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -51,6 +51,18 @@ class TestFindConfig:
         monkeypatch.chdir(tmp_path)
         assert _find_config("config.ini") == str(conf_dir / "config.ini")
 
+    def test_xdg_empty_string_falls_back_to_home(self, tmp_path, monkeypatch):
+        """XDG_CONFIG_HOME='' (set but empty) falls back to ~/.config, not a relative path."""
+        fake_home = tmp_path / "home"
+        conf_dir = fake_home / ".config" / "speedtest-z"
+        conf_dir.mkdir(parents=True)
+        (conf_dir / "config.ini").write_text("[general]\n")
+
+        monkeypatch.setenv("XDG_CONFIG_HOME", "")  # set but empty
+        monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.chdir(tmp_path)
+        assert _find_config("config.ini") == str(conf_dir / "config.ini")
+
     def test_etc_fallback(self, tmp_path, monkeypatch):
         """/etc/speedtest-z/ にフォールバック"""
         monkeypatch.chdir(tmp_path)

--- a/tests/test_grafana.py
+++ b/tests/test_grafana.py
@@ -691,3 +691,26 @@ class TestSendEmptyFilter:
             sender.send(data)
         mock_instance.send_bulk.assert_not_called()
         mock_grafana.send.assert_not_called()
+
+
+# --- Plaintext endpoint detection ---
+
+
+class TestIsPlaintextRemote:
+    """_is_plaintext_remote() flags only non-local plaintext endpoints."""
+
+    def test_https_is_secure(self):
+        from speedtest_z.sender import _is_plaintext_remote
+
+        assert _is_plaintext_remote("https://example.com/push") is False
+
+    def test_http_remote_is_plaintext(self):
+        from speedtest_z.sender import _is_plaintext_remote
+
+        assert _is_plaintext_remote("http://example.com/push") is True
+
+    def test_http_localhost_not_flagged(self):
+        from speedtest_z.sender import _is_plaintext_remote
+
+        assert _is_plaintext_remote("http://localhost:4318/v1/metrics") is False
+        assert _is_plaintext_remote("http://127.0.0.1:9090/api/v1/write") is False

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -39,6 +39,23 @@ class TestCheckUrl:
             status, reason = _check_url("https://example.com/")
         assert status == 200
 
+    def test_fallback_to_get_on_501(self):
+        """HEAD returning 501 (Not Implemented) also falls back to GET."""
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.reason = "OK"
+        mock_resp.__enter__ = lambda self: self
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        def side_effect(req, timeout=10):
+            if req.get_method() == "HEAD":
+                raise urllib.error.HTTPError(req.full_url, 501, "Not Implemented", {}, None)
+            return mock_resp
+
+        with patch("speedtest_z.healthcheck.urllib.request.urlopen", side_effect=side_effect):
+            status, reason = _check_url("https://example.com/")
+        assert status == 200
+
     def test_http_error(self):
         """HTTP エラー（405以外）は即座にエラーコードを返す"""
         with patch(
@@ -89,6 +106,16 @@ class TestCheckSites:
         assert result == 1
         captured = capsys.readouterr()
         assert "FAIL" in captured.out
+
+    def test_failure_shows_reason(self, capsys):
+        """The failure reason is included in the output."""
+        with patch(
+            "speedtest_z.healthcheck.urllib.request.urlopen",
+            side_effect=Exception("Connection refused"),
+        ):
+            check_sites(["cloudflare"])
+        captured = capsys.readouterr()
+        assert "Connection refused" in captured.out
 
     def test_specific_sites(self, capsys):
         """特定サイトのみチェック"""

--- a/tests/test_sites/test_boxtest.py
+++ b/tests/test_sites/test_boxtest.py
@@ -322,7 +322,7 @@ class TestRunBoxtest:
             mock_app.wait.until.return_value = toggle_btn
             run_boxtest(mock_app)
 
-        mock_app.take_snapshot.assert_any_call("boxtest_final")
+        mock_app.take_snapshot.assert_any_call("boxtest")
 
     def test_size_toggle_clicks(self, mock_app):
         """Toggle button is clicked until target size is reached."""


### PR DESCRIPTION
## Summary

Remaining low-severity findings from the full-branch code review (follow-up to #9 and #10). Each change is small and low-risk; no behavioral change to the measurement happy path.

## Changes

- **cli**: close the `SenderManager` before swapping in `OutputCollector` for `--output json/csv`, so the OTel exporter background thread is released instead of leaking for the rest of the run.
- **runner**: `os.makedirs(snapshot_dir, exist_ok=True)` (removes the check-then-create TOCTOU and matches the chrome-profile dir handling).
- **sender**: log a warning when the Grafana `remote_write_url` / OTel `endpoint` is not `https://` (credentials/headers would otherwise be sent over plaintext).
- **healthcheck**: import `urllib.error` explicitly (was relying on a transitive import via `urllib.request`); fall back to GET on **501** as well as 405; print the failure **reason** on `FAIL` lines for easier diagnosis.
- **config**: fall back to `~/.config` when `XDG_CONFIG_HOME` is set but empty (previously produced a relative path and skipped the XDG location).
- **cloudflare**: split the redundant `except (NoSuchElementException, Exception)` — unexpected errors now log at `warning` instead of being hidden at `debug`.
- **boxtest**: take a single snapshot in `finally` (consistent with the other runners, and captured on early return too); parse the numeric token without `IndexError` on empty text.
- **inonius**: parse the MSS token without `IndexError` on empty text.
- **types**: remove the unused `ZabbixItem` TypedDict.

## Tests

Added coverage for the HEAD→GET 501 fallback, the FAIL-line reason output, and the empty `XDG_CONFIG_HOME` fallback. `ruff` / `ruff format --check` / `mypy` clean; **306 passed, 9 skipped**.

## Still deferred (intentionally)

- `_load_with_retry` `"err_"` page-source match — narrowing it risks false-negatives (missing real Chrome error pages) for a low-severity, self-healing false-positive.
- GitHub Actions SHA-pinning — kept `@v4`/`@v5` major tags (SHA-pinning adds Dependabot/maintenance overhead for a small repo).
- Deploy/packaging niceties (`SeleniumCleaner.cron` rm-rf scoping, systemd `/var/log` path vs `logging.ini`, deb changelog entry) — separate from the application code; can follow up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)