### PR TITLE
fix: harden deploy/packaging scripts (cron scope, drop unused /var/log)

### DIFF
--- a/debian/speedtest-z.postinst
+++ b/debian/speedtest-z.postinst
@@ -9,10 +9,10 @@ case "$1" in
                 --no-create-home --quiet speedtest-z
         fi
 
-        # ディレクトリ作成
+        # Create runtime directories (logs go to logger.log under the working
+        # directory and to journald, so no separate /var/log dir is needed)
         install -d -o speedtest-z -g speedtest-z -m 0755 /var/lib/speedtest-z
         install -d -o speedtest-z -g speedtest-z -m 0755 /var/lib/speedtest-z/snapshots
-        install -d -o speedtest-z -g speedtest-z -m 0755 /var/log/speedtest-z
 
         # config.ini の権限設定（トークンを含む可能性があるため）
         if [ -f /etc/speedtest-z/config.ini ]; then

--- a/debian/speedtest-z.postrm
+++ b/debian/speedtest-z.postrm
@@ -3,11 +3,8 @@ set -e
 
 case "$1" in
     purge)
-        # ログとデータディレクトリの削除
-        rm -rf /var/log/speedtest-z
+        # Remove data and config directories (logs live under /var/lib)
         rm -rf /var/lib/speedtest-z
-
-        # 設定ディレクトリの削除
         rm -rf /etc/speedtest-z
 
         # speedtest-z ユーザ/グループの削除

--- a/debian/speedtest-z.service
+++ b/debian/speedtest-z.service
@@ -13,7 +13,7 @@ Group=speedtest-z
 NoNewPrivileges=yes
 ProtectSystem=strict
 ProtectHome=yes
-ReadWritePaths=/var/log/speedtest-z /var/lib/speedtest-z /tmp
+ReadWritePaths=/var/lib/speedtest-z /tmp
 PrivateTmp=yes
 
 [Install]

--- a/deploy/SeleniumCleaner.cron
+++ b/deploy/SeleniumCleaner.cron
@@ -1,1 +1,4 @@
-0  *    * * *   root    find /tmp -mmin +180 \( -name "*com.google.Chrome.*" -or -name "*org.chromium.Chromium.*" \) -type d -exec rm -vfr {} \; | logger --tag SeleniumCleaner
+# Remove stale Chrome/Chromium temp dirs left by Selenium. Scoped to direct
+# children of /tmp (-mindepth/-maxdepth 1, no recursion) and to dirs older than
+# 180 min, to avoid touching /tmp itself or attacker-named nested paths.
+0  *    * * *   root    find /tmp -mindepth 1 -maxdepth 1 -mmin +180 -type d \( -name "*com.google.Chrome.*" -o -name "*org.chromium.Chromium.*" \) -exec rm -vrf {} \; | logger --tag SeleniumCleaner

--- a/rpm/post-install.sh
+++ b/rpm/post-install.sh
@@ -2,10 +2,10 @@
 # RPM %post — パッケージインストール後に実行
 # $1: 1=新規インストール, 2=アップグレード
 
-# ディレクトリ作成
+# Create runtime directories (logs go to logger.log under the working
+# directory and to journald, so no separate /var/log dir is needed)
 install -d -o speedtest-z -g speedtest-z -m 0755 /var/lib/speedtest-z
 install -d -o speedtest-z -g speedtest-z -m 0755 /var/lib/speedtest-z/snapshots
-install -d -o speedtest-z -g speedtest-z -m 0755 /var/log/speedtest-z
 
 # config.ini の権限設定（トークンを含む可能性があるため）
 if [ -f /etc/speedtest-z/config.ini ]; then

--- a/rpm/post-remove.sh
+++ b/rpm/post-remove.sh
@@ -2,10 +2,9 @@
 # RPM %postun — パッケージ削除後に実行
 # $1: 0=最終削除, 1=アップグレード
 
-if [ $1 -eq 0 ]; then
+if [ "$1" -eq 0 ]; then
     rm -rf /opt/venvs/speedtest-z
     rm -rf /etc/speedtest-z
-    rm -rf /var/log/speedtest-z
     rm -rf /var/lib/speedtest-z
     userdel speedtest-z 2>/dev/null || true
 fi

--- a/rpm/pre-remove.sh
+++ b/rpm/pre-remove.sh
@@ -2,7 +2,7 @@
 # RPM %preun — パッケージ削除前に実行
 # $1: 0=最終削除, 1=アップグレード
 
-if [ $1 -eq 0 ]; then
+if [ "$1" -eq 0 ]; then
     systemctl stop speedtest-z.timer speedtest-z.service 2>/dev/null || true
     systemctl disable speedtest-z.timer speedtest-z.service 2>/dev/null || true
 fi


### PR DESCRIPTION
## Summary

Deploy/packaging hardening from the code review (the deploy-side low findings). No application code changes; CI test suite is unaffected.

## Changes

- **cron** (`deploy/SeleniumCleaner.cron`): scope the Selenium Chrome/Chromium temp-dir cleaner to **direct children of `/tmp`** (`-mindepth 1 -maxdepth 1`, no recursion) and dirs older than 180 min, so the root `rm -rf` cannot act on `/tmp` itself or descend into attacker-named nested paths. Switched `-or` → POSIX `-o`.
- **packaging**: stop creating the **unused `/var/log/speedtest-z`**. `logging.ini`'s file handler writes `logger.log` relative to the working directory (`/var/lib/speedtest-z` under systemd), and the console handler goes to stderr → journald, so the separate `/var/log` dir was created but never written to. Removed from `debian/speedtest-z.postinst`, `debian/speedtest-z.postrm`, `rpm/post-install.sh`, `rpm/post-remove.sh`, and the service `ReadWritePaths`.
- **rpm**: quote `$1` in `pre-remove.sh` / `post-remove.sh` (shellcheck SC2086).

All deb/rpm maintainer scripts are now **shellcheck-clean**.

## Verification

- `shellcheck -s sh` clean on all packaging scripts.
- `pytest`: 309 passed, 9 skipped (unaffected — no app code touched).
- `grep` confirms no remaining `/var/log/speedtest-z` references.

## Notes

- If you would prefer logs under `/var/log/speedtest-z` (the conventional location) rather than `/var/lib/speedtest-z/logger.log`, that needs a packaged `logging.ini` with an absolute path (the repo `logging.ini` keeps a relative path for local-dev portability) — happy to do that instead if preferred.
- The **deb changelog** auto-update item is intentionally left for the upcoming release-please migration, which reworks the release/versioning flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)