### PR TITLE
test: assert version fallback by semver shape, not a fixed value

### DIFF
--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,5 +1,6 @@
 """__init__.py のテスト"""
 
+import re
 from unittest.mock import patch
 
 
@@ -19,17 +20,21 @@ class TestVersion:
         assert len(__version__) > 0
 
     def test_version_fallback(self):
-        """PackageNotFoundError 時のフォールバック"""
+        """On PackageNotFoundError, __version__ falls back to a version string.
+
+        release-please keeps the fallback literal in __init__.py in sync with the
+        released version, so assert the semver shape rather than a fixed value.
+        """
         from importlib.metadata import PackageNotFoundError
 
         with patch("importlib.metadata.version", side_effect=PackageNotFoundError()):
-            # モジュールを再ロード
+            # Reload the module so the fallback branch runs.
             import importlib
 
             import speedtest_z
 
             importlib.reload(speedtest_z)
-            assert speedtest_z.__version__ == "0.0.0"
+            assert re.match(r"^\d+\.\d+\.\d+", speedtest_z.__version__)
 
-            # 元に戻す
+            # Restore the real version.
             importlib.reload(speedtest_z)


### PR DESCRIPTION
## Summary

Fixes the test that broke when release-please started managing the in-package version.

release-please's `python` release type updates the `__version__` fallback literal in `speedtest_z/__init__.py` (it bumped `"0.0.0"` → `"0.8.4"` in the 0.8.4 release PR #14). `test_version_fallback` asserted the exact value `"0.0.0"`, so PR #14's CI failed:

```
tests/test_init.py:32: assert speedtest_z.__version__ == "0.0.0"
E   AssertionError: assert '0.8.4' == '0.0.0'
```

## Change

`test_version_fallback` now asserts the fallback matches a **semver prefix** (`^\d+\.\d+\.\d+`) instead of a fixed value. This keeps the test meaningful (the `PackageNotFoundError` branch still returns a version string) while being stable across releases, regardless of what release-please syncs the literal to. Matches `0.0.0`, `0.8.4`, `0.9.0`, …

## Verification

`ruff` clean; full suite **309 passed, 9 skipped**. Verified the regex matches `0.0.0` (current main) and `0.8.4`/`0.9.0` (post-release-please).

## Follow-up

After this merges, release-please will regenerate PR #14 against the updated main; #14's CI will then pass and it can be merged to cut **0.8.4**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)