### PR TITLE
ci: bump GitHub Actions off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -24,7 +24,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,7 +16,7 @@ jobs:
       # GitHub Release. Set a RELEASE_PLEASE_TOKEN secret (a PAT or GitHub App
       # token) so that tag push triggers the PyPI/deb/rpm workflows — a tag
       # created with the default GITHUB_TOKEN does not trigger other workflows.
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
           config-file: release-please-config.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -23,7 +23,7 @@ jobs:
         run: python -m build
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/
@@ -36,7 +36,7 @@ jobs:
       id-token: write
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
@@ -54,7 +54,7 @@ jobs:
       id-token: write
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -35,7 +35,7 @@ jobs:
           dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
           dnf install -y gh
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary

Resolves the GitHub Actions **Node.js 20 deprecation** (Node 20 forced to Node 24 from 2026-06-16, removed 2026-09-16) by bumping every Node-based action to a Node 24 major. After this, no workflow action runs on Node 20.

## Changes

| Action | Before | After | Files |
|---|---|---|---|
| `actions/checkout` | v4 | **v6** | ci, release, deb, rpm |
| `actions/setup-python` | v5 | **v6** | ci, release |
| `actions/upload-artifact` | v4 | **v7** | release |
| `actions/download-artifact` | v4 | **v8** | release |
| `googleapis/release-please-action` | v4 | **v5** | release-please |

All are the latest majors (verified via the GitHub API) and run on Node 24. Usage is vanilla, so the bumps are low-risk.

### release-please-action v4 → v5 — verified safe

Checked `action.yml` and the v5.0.0 release notes:
- **The only breaking change is "upgrade to node24".** No input/behavior changes.
- Inputs used here (`token`, `config-file`, `manifest-file`) are unchanged in v5.
- Bundled release-please core moves 17.3.0 → 17.6.0 (bug fixes only), so the config and the in-flight 0.8.4 release PR (#16) regenerate equivalently.

## Not changed

- `pypa/gh-action-pypi-publish@release/v1` — a container action, unaffected by the Node runtime deprecation.

## Verification

All 5 workflow files parse as valid YAML; no `actions/*@v4|v5` or `release-please-action@v4` references remain. The bumped actions exercise on their respective triggers — PR CI here validates the `ci.yml` `checkout@v6`/`setup-python@v6` path; release/artifact/container/release-please paths validate at release time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)