### PR TITLE
fix: honor stream=stderr even when logging.ini is loaded

### DIFF
--- a/speedtest_z/config.py
+++ b/speedtest_z/config.py
@@ -37,7 +37,7 @@ def _find_config(name: str, cli_path: str | None = None) -> str | None:
     if os.path.isfile(xdg_path):
         return xdg_path
 
-    # システム全体の設定（deb パッケージ向け）
+    # System-wide configuration (for the deb/rpm packages).
     etc_path = os.path.join("/etc/speedtest-z", name)
     if os.path.isfile(etc_path):
         return etc_path
@@ -45,13 +45,40 @@ def _find_config(name: str, cli_path: str | None = None) -> str | None:
     return None
 
 
+def _redirect_console_logging_to_stderr() -> None:
+    """Point any stdout-bound StreamHandler at stderr.
+
+    Used in json/csv output mode so log records never mix into the structured
+    stdout payload, even when a logging.ini routes the console handler to stdout.
+    FileHandler is a StreamHandler subclass, but its stream is a file, so the
+    identity check against sys.stdout naturally leaves file handlers alone.
+    """
+    seen: set[int] = set()
+    loggers = [logging.getLogger()]
+    loggers += [logging.getLogger(name) for name in logging.root.manager.loggerDict]
+    for lg in loggers:
+        for handler in getattr(lg, "handlers", []):
+            if id(handler) in seen:
+                continue
+            seen.add(id(handler))
+            if isinstance(handler, logging.StreamHandler) and handler.stream is sys.stdout:
+                handler.setStream(sys.stderr)
+
+
 def _setup_logging(debug: bool = False, stream: str = "stdout") -> None:
-    """Initialize logging configuration."""
+    """Initialize logging configuration.
+
+    When *stream* is ``"stderr"`` (json/csv output mode), guarantee that no log
+    records reach stdout — even if a logging.ini routes the console handler
+    there — so the structured stdout payload stays clean.
+    """
     logging_ini = _find_config("logging.ini")
     if logging_ini:
         logging.config.fileConfig(logging_ini, disable_existing_loggers=False)
         if debug:
             logging.getLogger().setLevel(logging.DEBUG)
+        if stream == "stderr":
+            _redirect_console_logging_to_stderr()
     else:
         out = sys.stderr if stream == "stderr" else sys.stdout
         logging.basicConfig(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,9 +1,15 @@
 """設定ファイル探索のテスト"""
 
+import logging
 import os
+import sys
 from unittest.mock import patch
 
-from speedtest_z.config import _find_config, _setup_logging
+from speedtest_z.config import (
+    _find_config,
+    _redirect_console_logging_to_stderr,
+    _setup_logging,
+)
 from speedtest_z.runner import SpeedtestZ
 
 
@@ -139,6 +145,42 @@ class TestSetupLogging:
             _setup_logging(debug=True)
             call_kwargs = mock_basic.call_args
             assert call_kwargs[1]["level"] == 10  # logging.DEBUG
+
+    def test_redirect_console_logging_to_stderr(self):
+        """A stdout StreamHandler is redirected to stderr; file handlers untouched."""
+        root = logging.getLogger()
+        saved = root.handlers[:]
+        try:
+            stdout_handler = logging.StreamHandler(sys.stdout)
+            stderr_handler = logging.StreamHandler(sys.stderr)
+            root.handlers = [stdout_handler, stderr_handler]
+            _redirect_console_logging_to_stderr()
+            assert stdout_handler.stream is sys.stderr
+            assert stderr_handler.stream is sys.stderr  # already stderr, unchanged
+        finally:
+            root.handlers = saved
+
+    def test_setup_logging_stderr_redirects_with_ini(self, tmp_path, monkeypatch):
+        """With a logging.ini present, stream='stderr' triggers the redirect."""
+        (tmp_path / "logging.ini").write_text("[loggers]\nkeys=root\n")
+        monkeypatch.chdir(tmp_path)
+        with (
+            patch("speedtest_z.config.logging.config.fileConfig"),
+            patch("speedtest_z.config._redirect_console_logging_to_stderr") as mock_redirect,
+        ):
+            _setup_logging(debug=False, stream="stderr")
+            mock_redirect.assert_called_once()
+
+    def test_setup_logging_stdout_no_redirect_with_ini(self, tmp_path, monkeypatch):
+        """With a logging.ini present, the default stdout stream does not redirect."""
+        (tmp_path / "logging.ini").write_text("[loggers]\nkeys=root\n")
+        monkeypatch.chdir(tmp_path)
+        with (
+            patch("speedtest_z.config.logging.config.fileConfig"),
+            patch("speedtest_z.config._redirect_console_logging_to_stderr") as mock_redirect,
+        ):
+            _setup_logging(debug=False, stream="stdout")
+            mock_redirect.assert_not_called()
 
 
 class TestChromeProfileDir:


### PR DESCRIPTION
## Summary

Fixes the low-severity logging finding from the code review: `_setup_logging(stream="stderr")` (used in `--output json/csv` mode) was ignored when a `logging.ini` was present.

## Problem

`_setup_logging` honored the `stream` argument only in the `basicConfig` fallback (no `logging.ini`). When a `logging.ini` was found, `fileConfig` ran and `stream` was dropped — so a `logging.ini` whose console handler targets **stdout** would pollute the structured stdout payload in json/csv mode. (The repo's own `logging.ini` already uses stderr, so this was latent, but the API contract was broken for custom configs.)

## Fix

Add `_redirect_console_logging_to_stderr()` which, after `fileConfig`, repoints any `StreamHandler` whose stream is `sys.stdout` to `sys.stderr`. It is called only when `stream == "stderr"`. `FileHandler` is a `StreamHandler` subclass, but its stream is a file, so the identity check against `sys.stdout` leaves file handlers (e.g. `logger.log`) untouched.

Also translated the one remaining Japanese comment in `config.py` to English (public-repo policy).

## Tests

- `_redirect_console_logging_to_stderr` redirects a stdout handler and leaves a stderr handler unchanged (root handlers saved/restored, no global pollution).
- `_setup_logging(stream="stderr")` calls the redirect when a `logging.ini` is present; `stream="stdout"` does not.

`ruff` / `mypy` clean; **312 passed, 9 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)