### PR TITLE
ci: trigger release pipeline on release:published (align with reference repos)

### DIFF
--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -1,9 +1,8 @@
 name: Build .deb packages
 
 on:
-  push:
-    tags:
-      - "v*"
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       version:
@@ -72,26 +71,10 @@ jobs:
             mv "$deb" "$newname"
           done
 
-      - name: Wait for GitHub Release to exist
-        if: startsWith(github.ref, 'refs/tags/')
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          TAG="${GITHUB_REF_NAME}"
-          for i in $(seq 1 30); do
-            if gh release view "$TAG" >/dev/null 2>&1; then
-              echo "Release $TAG found"
-              exit 0
-            fi
-            echo "Waiting for release $TAG... ($i/30)"
-            sleep 30
-          done
-          echo "Release $TAG not found after 15 minutes, creating it"
-          # Tolerate races with the parallel jammy/noble jobs and the release workflow.
-          gh release view "$TAG" >/dev/null 2>&1 || gh release create "$TAG" --generate-notes || true
-
+      # The GitHub Release already exists (this workflow is triggered by
+      # release:published), so just attach the .deb assets to it.
       - name: Upload .deb to GitHub Release
-        if: startsWith(github.ref, 'refs/tags/')
+        if: github.event_name == 'release'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,13 +11,19 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    # Run release-please in JST so the CHANGELOG version-header date matches the
+    # JST merge day rather than the runner's UTC clock (release-please respects TZ).
+    env:
+      TZ: Asia/Tokyo
     steps:
-      # Maintains a release PR; merging it creates the vX.Y.Z tag and the
-      # GitHub Release. Set a RELEASE_PLEASE_TOKEN secret (a PAT or GitHub App
-      # token) so that tag push triggers the PyPI/deb/rpm workflows — a tag
-      # created with the default GITHUB_TOKEN does not trigger other workflows.
+      # Maintains a release PR; merging it creates the vX.Y.Z tag and publishes
+      # the GitHub Release. Use a fine-grained PAT (RELEASE_PLEASE_TOKEN) so the
+      # release:published event triggers the downstream PyPI/deb/rpm workflows —
+      # a release created by the default GITHUB_TOKEN cannot trigger other
+      # workflows (GitHub's recursion-prevention rule). Falls back to
+      # GITHUB_TOKEN on forks / PR CI where the secret is unavailable.
       - uses: googleapis/release-please-action@v5
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,31 @@
 name: Release to PyPI
 
+# Fires when release-please publishes the Release after its PR is merged.
+# release-please creates the tag/Release via a PAT (RELEASE_PLEASE_TOKEN), so
+# the release:published event propagates and triggers this pipeline; a release
+# created by the default GITHUB_TOKEN cannot trigger other workflows.
 on:
-  push:
-    tags:
-      - "v*"
+  release:
+    types: [published]
 
 jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Verify pyproject version matches tag
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PKG_VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          if [ "$TAG" != "$PKG_VERSION" ]; then
+            echo "::error::Tag v$TAG does not match version $PKG_VERSION in pyproject.toml"
+            exit 1
+          fi
+          echo "Verified: tag v$TAG matches version $PKG_VERSION"
+
   build:
+    needs: verify
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -70,13 +89,10 @@ jobs:
     needs: publish
     runs-on: ubuntu-latest
     steps:
-      - name: Extract version from tag
-        id: version
-        run: echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
       - name: Trigger homebrew-tap update
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
           gh api repos/shigechika/homebrew-tap/dispatches \
             -f event_type=update_speedtest_z \
-            -f 'client_payload[version]=${{ steps.version.outputs.tag }}'
-        env:
-          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+            -f "client_payload[version]=${GITHUB_REF_NAME}"

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -1,9 +1,8 @@
 name: Build RPM packages
 
 on:
-  push:
-    tags:
-      - "v*"
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       version:
@@ -29,7 +28,7 @@ jobs:
         run: gem install fpm
 
       - name: Install GitHub CLI
-        if: startsWith(github.ref, 'refs/tags/')
+        if: github.event_name == 'release'
         run: |
           dnf install -y 'dnf-command(config-manager)'
           dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
@@ -72,7 +71,7 @@ jobs:
           mkdir -p "${STAGING}/usr/bin"
           ln -sf /opt/venvs/speedtest-z/bin/speedtest-z "${STAGING}/usr/bin/speedtest-z"
 
-          # 設定ファイル
+          # Config files
           mkdir -p "${STAGING}/etc/speedtest-z"
           cp config.ini-sample "${STAGING}/etc/speedtest-z/config.ini"
           cp logging.ini "${STAGING}/etc/speedtest-z/logging.ini"
@@ -81,7 +80,7 @@ jobs:
           mkdir -p "${STAGING}/etc/default"
           cp deploy/speedtest-z.default "${STAGING}/etc/default/speedtest-z"
 
-          # systemd ユニット
+          # systemd units
           mkdir -p "${STAGING}/usr/lib/systemd/system"
           cp debian/speedtest-z.service "${STAGING}/usr/lib/systemd/system/"
           cp debian/speedtest-z.timer "${STAGING}/usr/lib/systemd/system/"
@@ -127,26 +126,10 @@ jobs:
           echo "=== Scripts ==="
           rpm -qp --scripts speedtest-z-*.rpm
 
-      - name: Wait for GitHub Release to exist
-        if: startsWith(github.ref, 'refs/tags/')
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          TAG="${GITHUB_REF_NAME}"
-          for i in $(seq 1 30); do
-            if gh release view "$TAG" >/dev/null 2>&1; then
-              echo "Release $TAG found"
-              exit 0
-            fi
-            echo "Waiting for release $TAG... ($i/30)"
-            sleep 30
-          done
-          echo "Release $TAG not found after 15 minutes, creating it"
-          # Tolerate a race with the release workflow.
-          gh release view "$TAG" >/dev/null 2>&1 || gh release create "$TAG" --generate-notes || true
-
+      # The GitHub Release already exists (this workflow is triggered by
+      # release:published), so just attach the .rpm asset to it.
       - name: Upload RPM to GitHub Release
-        if: startsWith(github.ref, 'refs/tags/')
+        if: github.event_name == 'release'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,9 +67,9 @@ python -m build
 
 - `.github/workflows/ci.yml` — push/PR 時に構文チェック + ビルドテスト（Python 3.10〜3.14）
 - `.github/workflows/release-please.yml` — main への push 時に release-please が Release PR を維持。マージで `vX.Y.Z` タグと GitHub Release を自動作成
-- `.github/workflows/release.yml` — `v*` タグ push 時に PyPI へ自動公開（Trusted Publishers）
-- `.github/workflows/deb.yml` — `v*` タグ push 時に jammy/noble 向け .deb ビルド → GitHub Release にアップロード
-- `.github/workflows/rpm.yml` — `v*` タグ push 時に Rocky 9 向け .rpm ビルド（fpm）→ GitHub Release にアップロード
+- `.github/workflows/release.yml` — Release 公開時（`release: published`）に PyPI へ自動公開（Trusted Publishers）。`verify` ジョブで pyproject の version とタグの一致を確認
+- `.github/workflows/deb.yml` — Release 公開時に jammy/noble 向け .deb ビルド → 当該 Release にアップロード（手動は workflow_dispatch）
+- `.github/workflows/rpm.yml` — Release 公開時に Rocky 9 向け .rpm ビルド（fpm）→ 当該 Release にアップロード（手動は workflow_dispatch）
 
 ## リリース手順（release-please）
 
@@ -78,9 +78,9 @@ python -m build
 1. **Conventional Commits** で main にマージする（`feat:` → minor、`fix:` → patch、`feat!:`/`BREAKING CHANGE` → 1.0 未満は minor）
 2. release-please が **Release PR** を自動で開く/更新する（次バージョン + CHANGELOG エントリを含む）
 3. README 等の更新が必要なら通常の PR で先に入れておく
-4. Release PR をマージすると `vX.Y.Z` タグと GitHub Release が作成され、`release.yml`（PyPI）・`deb.yml`・`rpm.yml` が発火する
+4. Release PR をマージすると `vX.Y.Z` タグと GitHub Release が公開され、その `release: published` イベントで `release.yml`（PyPI）・`deb.yml`・`rpm.yml` が発火する
 
-**重要: タグ起動を効かせるには PAT が必要。** release-please が `GITHUB_TOKEN` で作成したタグは他ワークフローを起動しない（GitHub の仕様）。リポジトリシークレット `RELEASE_PLEASE_TOKEN`（PAT もしくは GitHub App トークン）を設定すると、release-please が作るタグで PyPI/deb/rpm が自動発火する。未設定時は release-please 自体は動くが、ビルド/公開は手動発火（`deb.yml`/`rpm.yml` の workflow_dispatch 等）が必要。
+**重要: Release 起動には PAT が必要。** release-please が `GITHUB_TOKEN` で公開した Release は他ワークフローを起動しない（GitHub の仕様）。リポジトリシークレット `RELEASE_PLEASE_TOKEN`（PAT もしくは GitHub App トークン）を設定すると、release-please が公開する Release の `release: published` で PyPI/deb/rpm が自動発火する。未設定時は release-please 自体は動くが、ビルド/公開は手動発火（`deb.yml`/`rpm.yml` の workflow_dispatch 等）が必要。
 
 **重要: PyPI はバージョンの上書きを許可しない。** release-please は常に新しいバージョンを採番するためこの問題は基本的に起きないが、公開済みバージョンの再公開はできない点に留意する。
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,19 @@
       "changelog-path": "CHANGELOG.md",
       "include-v-in-tag": true,
       "include-component-in-tag": false,
-      "bump-minor-pre-major": true
+      "bump-minor-pre-major": true,
+      "changelog-sections": [
+        { "type": "feat", "section": "Features" },
+        { "type": "fix", "section": "Bug Fixes" },
+        { "type": "perf", "section": "Performance" },
+        { "type": "refactor", "section": "Refactoring" },
+        { "type": "docs", "section": "Documentation", "hidden": true },
+        { "type": "style", "section": "Style", "hidden": true },
+        { "type": "test", "section": "Tests", "hidden": true },
+        { "type": "build", "section": "Build", "hidden": true },
+        { "type": "ci", "section": "CI", "hidden": true },
+        { "type": "chore", "section": "Chores", "hidden": true }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary

Aligns the release/CI handling with the established pattern in `junos-ops` and `kb/jquants-mcp`: the PyPI/deb/rpm workflows now fire on **`release: types: [published]`** instead of `push: tags: v*`.

release-please publishes the GitHub Release via the `RELEASE_PLEASE_TOKEN` PAT, so the `release:published` event propagates and drives the pipeline. This is the canonical "a release happened" signal and is exactly the approach the reference repos document (a release/tag created by the default `GITHUB_TOKEN` cannot trigger other workflows).

## Changes

- **release.yml / deb.yml / rpm.yml**: `on: push: tags: v*` → `on: release: types: [published]` (deb/rpm keep `workflow_dispatch` for manual builds). Since the Release already exists (it's the trigger), the **"wait for release / create if missing"** steps are removed and asset uploads are guarded by `if: github.event_name == 'release'`.
- **release.yml**: add a `verify` job that asserts `pyproject.toml` `version` matches the tag before building (junos-ops pattern); simplify the Homebrew notify to use `github.ref_name`.
- **release-please.yml**: run with `TZ=Asia/Tokyo` so the CHANGELOG version-header date is JST (jquants-mcp); `token` falls back to `secrets.GITHUB_TOKEN`; clarified the comment.
- **release-please-config.json**: add explicit `changelog-sections` (junos-ops) — `feat`/`fix`/`perf`/`refactor` shown, `docs`/`style`/`test`/`build`/`ci`/`chore` hidden.
- **rpm.yml**: translate the remaining Japanese comments to English (the comment-migration sweep didn't cover workflow YAMLs).
- **CLAUDE.md**: update the CI/CD + release-procedure docs for the `release:published` flow.

## Reference

Patterns taken from `~/src/junos-ops/.github/workflows/{release,deb,rpm,release-please}.yml` and `~/src/kb/jquants-mcp/.github/workflows/release-please.yml`.

## Verification

All workflow YAML parses; `release-please-config.json` valid; the three release workflows now trigger on `release:published`; no Japanese remains in any workflow YAML; `pytest` 309 passed (no app code changed).

> Note: this changes future releases only — 0.8.4 already shipped via the prior tag trigger. The new trigger first exercises on the next release (≥0.8.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)