### PR TITLE
style: translate code comments and docstrings to English

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,11 @@ __pycache__/
 dist/
 build/
 
+# Coverage
+.coverage
+.coverage.*
+htmlcov/
+
 # venv
 .venv/
 

--- a/debian/speedtest-z.postinst
+++ b/debian/speedtest-z.postinst
@@ -3,7 +3,7 @@ set -e
 
 case "$1" in
     configure)
-        # speedtest-z システムユーザ作成
+        # Create the speedtest-z system user
         if ! getent passwd speedtest-z >/dev/null 2>&1; then
             adduser --system --group --home /var/lib/speedtest-z \
                 --no-create-home --quiet speedtest-z
@@ -14,13 +14,13 @@ case "$1" in
         install -d -o speedtest-z -g speedtest-z -m 0755 /var/lib/speedtest-z
         install -d -o speedtest-z -g speedtest-z -m 0755 /var/lib/speedtest-z/snapshots
 
-        # config.ini の権限設定（トークンを含む可能性があるため）
+        # Set config.ini permissions (it may contain tokens)
         if [ -f /etc/speedtest-z/config.ini ]; then
             chown root:speedtest-z /etc/speedtest-z/config.ini
             chmod 0640 /etc/speedtest-z/config.ini
         fi
 
-        # /etc/default/speedtest-z のリネーム（dh_install で配置した名前を修正）
+        # Rename /etc/default/speedtest-z (fix the name placed by dh_install)
         if [ -f /etc/default/speedtest-z.default ] && [ ! -f /etc/default/speedtest-z ]; then
             mv /etc/default/speedtest-z.default /etc/default/speedtest-z
         elif [ -f /etc/default/speedtest-z.default ]; then

--- a/debian/speedtest-z.postrm
+++ b/debian/speedtest-z.postrm
@@ -7,7 +7,7 @@ case "$1" in
         rm -rf /var/lib/speedtest-z
         rm -rf /etc/speedtest-z
 
-        # speedtest-z ユーザ/グループの削除
+        # Remove the speedtest-z user/group
         if getent passwd speedtest-z >/dev/null 2>&1; then
             deluser --quiet --system speedtest-z || true
         fi

--- a/rpm/post-install.sh
+++ b/rpm/post-install.sh
@@ -1,17 +1,17 @@
 #!/bin/sh
-# RPM %post — パッケージインストール後に実行
-# $1: 1=新規インストール, 2=アップグレード
+# RPM %post — run after package installation
+# $1: 1=new install, 2=upgrade
 
 # Create runtime directories (logs go to logger.log under the working
 # directory and to journald, so no separate /var/log dir is needed)
 install -d -o speedtest-z -g speedtest-z -m 0755 /var/lib/speedtest-z
 install -d -o speedtest-z -g speedtest-z -m 0755 /var/lib/speedtest-z/snapshots
 
-# config.ini の権限設定（トークンを含む可能性があるため）
+# Set config.ini permissions (it may contain tokens)
 if [ -f /etc/speedtest-z/config.ini ]; then
     chown root:speedtest-z /etc/speedtest-z/config.ini
     chmod 0640 /etc/speedtest-z/config.ini
 fi
 
-# systemd デーモンリロード
+# Reload systemd daemon
 systemctl daemon-reload 2>/dev/null || true

--- a/rpm/post-remove.sh
+++ b/rpm/post-remove.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
-# RPM %postun — パッケージ削除後に実行
-# $1: 0=最終削除, 1=アップグレード
+# RPM %postun — run after package removal
+# $1: 0=final removal, 1=upgrade
 
 if [ "$1" -eq 0 ]; then
     rm -rf /opt/venvs/speedtest-z

--- a/rpm/pre-install.sh
+++ b/rpm/pre-install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
-# RPM %pre — パッケージインストール前に実行
-# $1: 1=新規インストール, 2=アップグレード
+# RPM %pre — run before package installation
+# $1: 1=new install, 2=upgrade
 
 if ! getent passwd speedtest-z >/dev/null 2>&1; then
     useradd -r -s /sbin/nologin -d /var/lib/speedtest-z speedtest-z

--- a/rpm/pre-remove.sh
+++ b/rpm/pre-remove.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
-# RPM %preun — パッケージ削除前に実行
-# $1: 0=最終削除, 1=アップグレード
+# RPM %preun — run before package removal
+# $1: 0=final removal, 1=upgrade
 
 if [ "$1" -eq 0 ]; then
     systemctl stop speedtest-z.timer speedtest-z.service 2>/dev/null || true

--- a/speedtest_z/cli.py
+++ b/speedtest_z/cli.py
@@ -21,16 +21,16 @@ def _show_manual() -> None:
     import pydoc
     from importlib.resources import files
 
-    # ロケールに応じて日本語版/英語版を選択
+    # Select the Japanese/English version based on locale
     readme = "README.ja.md" if _LANG_JA else "README.md"
 
     text = None
 
-    # 1. importlib.resources でパッケージ内から読み込み (pip install 時)
+    # 1. Read from inside the package via importlib.resources (pip install)
     with contextlib.suppress(FileNotFoundError, TypeError):
         text = files("speedtest_z").joinpath(readme).read_text(encoding="utf-8")
 
-    # 2. フォールバック: リポジトリルートの README (開発時)
+    # 2. Fallback: README at the repository root (development)
     if not text:
         dev_path = os.path.normpath(os.path.join(os.path.dirname(__file__), os.pardir, readme))
         if os.path.isfile(dev_path):
@@ -169,19 +169,19 @@ def main() -> None:
 
     args = parser.parse_args()
 
-    # --man は Chrome 不要で応答
+    # --man responds without needing Chrome
     if args.man:
         _show_manual()
         return
 
-    # --list-sites は Chrome 不要で応答
+    # --list-sites responds without needing Chrome
     if args.list_sites:
         print("Available test sites:")
         for site in AVAILABLE_SITES:
             print(f"  {site}")
         return
 
-    # --check は Chrome 不要で応答
+    # --check responds without needing Chrome
     if args.check:
         from speedtest_z.healthcheck import check_sites
 
@@ -189,12 +189,12 @@ def main() -> None:
 
     _init_logging(args)
 
-    # config.ini の存在チェック（必須）
+    # Check that config.ini exists (required)
     config_path = _find_config("config.ini", args.config)
     if config_path is None:
         logger.error(_msg("config_not_found"))
         sys.exit(1)
-    args.config = config_path  # 見つかったパスで上書き
+    args.config = config_path  # overwrite with the resolved path
 
     sites = args.sites if args.sites else AVAILABLE_SITES
     if not _confirm_execution(args, sites):
@@ -206,7 +206,7 @@ def main() -> None:
 
     app = SpeedtestZ(args)
 
-    # json/csv モードでは SenderManager の代わりに OutputCollector を使う
+    # In json/csv mode, use OutputCollector instead of SenderManager
     output_fmt = getattr(args, "output", "zabbix")
     if output_fmt in ("json", "csv"):
         from speedtest_z.output import OutputCollector

--- a/speedtest_z/grafana.py
+++ b/speedtest_z/grafana.py
@@ -12,8 +12,8 @@ import urllib.request
 logger = logging.getLogger("speedtest-z")
 
 
-# --- Protobuf 手動エンコーダー（protobuf パッケージ不要） ---
-# Prometheus Remote Write の proto 定義:
+# --- Manual Protobuf encoder (no protobuf package required) ---
+# Prometheus Remote Write proto definitions:
 #   WriteRequest { repeated TimeSeries timeseries = 1; }
 #   TimeSeries   { repeated Label labels = 1; repeated Sample samples = 2; }
 #   Label        { string name = 1; string value = 2; }
@@ -120,14 +120,14 @@ class GrafanaSender:
             key = item.get("key", "")
             value_str = item.get("value", "")
 
-            # 数値でない値はスキップ（server-locations, POP 等）
+            # skip non-numeric values (server-locations, POP, etc.)
             try:
                 value = float(value_str)
             except (ValueError, TypeError):
                 logger.debug(f"Grafana skip: {key} = {value_str} (non-numeric)")
                 continue
 
-            # key を site と metric に分離（例: cloudflare.download）
+            # split key into site and metric (e.g. cloudflare.download)
             parts = key.split(".", 1)
             if len(parts) != 2:
                 continue

--- a/speedtest_z/i18n.py
+++ b/speedtest_z/i18n.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 import locale
 import os
 
-# ロケール判定（ja_JP 等で始まれば日本語）
+# Locale detection (Japanese if it starts with ja_JP etc.)
 _LANG_JA: bool = (locale.getlocale()[0] or os.environ.get("LANG", "")).startswith("ja")
 
-# ユーザ向けメッセージ辞書 (日本語, 英語)
+# User-facing message dictionary (Japanese, English)
 _MESSAGES: dict[str, tuple[str, str]] = {
     "config_not_found_cli": (
         "{path} が見つかりません",

--- a/speedtest_z/otel.py
+++ b/speedtest_z/otel.py
@@ -19,8 +19,8 @@ class OtelSender:
     def __init__(self, endpoint: str, headers: dict[str, str], host: str) -> None:
         """Initialize OtelSender with OTLP exporter and MeterProvider."""
         self.host = host
-        # endpoint をプログラムで渡す場合は /v1/metrics まで含める必要がある
-        # （環境変数 OTEL_EXPORTER_OTLP_ENDPOINT の場合のみ SDK が自動付加）
+        # When passing the endpoint programmatically, it must include /v1/metrics
+        # (the SDK only appends it automatically for the OTEL_EXPORTER_OTLP_ENDPOINT env var).
         if not endpoint.endswith("/v1/metrics"):
             endpoint = endpoint.rstrip("/") + "/v1/metrics"
         self.exporter = OTLPMetricExporter(
@@ -35,11 +35,11 @@ class OtelSender:
         )
         reader = PeriodicExportingMetricReader(
             self.exporter,
-            export_interval_millis=60000,  # 手動 flush するので長めに設定
+            export_interval_millis=60000,  # set long since we flush manually
         )
         self.provider = MeterProvider(resource=self.resource, metric_readers=[reader])
         self.meter = self.provider.get_meter("speedtest-z")
-        # 作成済み gauge をキャッシュ
+        # cache created gauges
         self._gauges: dict[str, Any] = {}
 
     def send(self, data_list: list[dict[str, str]]) -> None:
@@ -59,14 +59,14 @@ class OtelSender:
             site, metric = parts
             metric_name = f"speedtest_{metric.replace('-', '_')}"
 
-            # gauge を作成（同名なら SDK が内部でキャッシュ）
+            # create the gauge (the SDK caches it internally if the name matches)
             if metric_name not in self._gauges:
                 self._gauges[metric_name] = self.meter.create_gauge(metric_name)
 
             host = item.get("host", self.host)
             self._gauges[metric_name].set(value, {"site": site, "host": host})
 
-        # 即時エクスポート
+        # export immediately
         self.provider.force_flush()
 
     def shutdown(self) -> None:

--- a/speedtest_z/output.py
+++ b/speedtest_z/output.py
@@ -63,7 +63,7 @@ class OutputCollector:
     def _flush_json(self) -> None:
         """Output as JSON array."""
         json.dump(self._records, sys.stdout, ensure_ascii=False, indent=2)
-        print()  # 末尾改行
+        print()  # trailing newline
 
     def _flush_csv(self) -> None:
         """Output as CSV with header."""

--- a/speedtest_z/runner.py
+++ b/speedtest_z/runner.py
@@ -39,7 +39,7 @@ class SpeedtestZ:
 
     def __init__(self, args: argparse.Namespace | None = None) -> None:
         """Initialize SpeedtestZ with CLI arguments and config file."""
-        # 設定ファイルの読み込み
+        # Load the config file
         self.config = configparser.ConfigParser()
         config_path = _find_config("config.ini", getattr(args, "config", None))
         if config_path:
@@ -48,7 +48,7 @@ class SpeedtestZ:
         else:
             logger.warning(_msg("config_not_found_fallback"))
 
-        # [general] — dry_run を優先、なければ旧名 dryrun にフォールバック
+        # [general] — prefer dry_run, falling back to the old name dryrun
         self.dryrun = self.config.getboolean("general", "dry_run", fallback=None)
         if self.dryrun is None:
             self.dryrun = self.config.getboolean("general", "dryrun", fallback=True)
@@ -61,7 +61,7 @@ class SpeedtestZ:
             )
         )
 
-        # CLI 引数でオーバーライド
+        # Override with CLI arguments
         self.explicit_sites = False
         self.auto_consent = False
         if args:
@@ -96,10 +96,10 @@ class SpeedtestZ:
         if self.snapshot_enable:
             os.makedirs(self.snapshot_dir, exist_ok=True)
 
-        # WebDriver の初期化
+        # Initialize the WebDriver
         self._init_driver()
 
-        # SIGTERM ハンドリング
+        # SIGTERM handling
         signal.signal(signal.SIGTERM, self._handle_sigterm)
 
     def _handle_sigterm(self, signum: int, frame: types_mod.FrameType | None) -> None:

--- a/speedtest_z/sites/__init__.py
+++ b/speedtest_z/sites/__init__.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from speedtest_z.runner import SpeedtestZ
 
-# 利用可能なテストサイト一覧
+# List of available test sites
 AVAILABLE_SITES = [
     "cloudflare",
     "netflix",

--- a/speedtest_z/sites/boxtest.py
+++ b/speedtest_z/sites/boxtest.py
@@ -109,7 +109,7 @@ def run_boxtest(app: SpeedtestZ) -> None:
             "//*[local-name()='tspan' and contains(., 'Avg:')]"
         )
 
-        # 数値項目
+        # Numeric items
         numeric_items = {
             "DownloadSpeed": f"{base_xp}/td[2]",
             "DownloadDuration": f"{base_xp}/td[3]",
@@ -119,7 +119,7 @@ def run_boxtest(app: SpeedtestZ) -> None:
             "UploadRTT": f"{base_xp}/td[7]",
             "latency": latency_xp,
         }
-        # 文字列項目（split しない）
+        # String items (not split)
         string_items = {
             "POP": f"{base_xp}/td[1]/b",
         }

--- a/speedtest_z/sites/google.py
+++ b/speedtest_z/sites/google.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("speedtest-z")
 
-# 注意: speed.googlefiber.net は HTTPS 非対応（HTTP のみ）
+# Note: speed.googlefiber.net does not support HTTPS (HTTP only)
 URL = "http://speed.googlefiber.net/"
 
 
@@ -27,7 +27,7 @@ def run_google(app: SpeedtestZ) -> None:
 
     try:
         logger.info("google: OPEN")
-        # 注意: speed.googlefiber.net は HTTPS 非対応（HTTP のみ）
+        # Note: speed.googlefiber.net does not support HTTPS (HTTP only)
         if not app._load_with_retry(URL):
             return
 

--- a/speedtest_z/sites/inonius.py
+++ b/speedtest_z/sites/inonius.py
@@ -78,7 +78,7 @@ def run_inonius(app: SpeedtestZ) -> None:
 
         start_xpath = "/html/body/div/astro-island/dialog/div/div/form/button[2]"
         if app.auto_consent:
-            # --yes: 同意ダイアログを自動クリック（同意兼スタート）
+            # --yes: auto-click the consent dialog (accept and start in one)
             try:
                 start_btn = WebDriverWait(app.driver, 5).until(
                     EC.element_to_be_clickable((By.XPATH, start_xpath))
@@ -86,21 +86,21 @@ def run_inonius(app: SpeedtestZ) -> None:
                 start_btn.click()
                 logger.info("inonius: Consent accepted and started (auto)")
             except TimeoutException:
-                # Cookie で dialog が出ない → フォールバック
+                # Dialog suppressed by cookie consent: fall back
                 if not _inonius_fallback_start(app):
                     return
         else:
-            # --yes なし: ユーザ操作を待つか、Cookie で dialog が出ない場合のフォールバック
+            # No --yes: wait for user action, or fall back if the dialog is suppressed by cookie
             try:
                 dialog = WebDriverWait(app.driver, 5).until(
                     EC.presence_of_element_located((By.CSS_SELECTOR, "dialog"))
                 )
-                # dialog が表示されたらユーザがクリックして閉じるのを待つ
+                # Once the dialog is shown, wait for the user to click and close it
                 logger.info("inonius: Waiting for user to accept consent dialog...")
                 WebDriverWait(app.driver, 120).until(lambda d: not dialog.is_displayed())
                 logger.info("inonius: Dialog closed by user")
             except TimeoutException:
-                # dialog が出ない（Cookie で記憶済み）→ フォールバック
+                # Dialog not shown (consent remembered by cookie): fall back
                 if not _inonius_fallback_start(app):
                     return
 

--- a/speedtest_z/sites/mlab.py
+++ b/speedtest_z/sites/mlab.py
@@ -36,7 +36,7 @@ def run_mlab(app: SpeedtestZ) -> None:
             except TimeoutException:
                 logger.debug("mlab: Consent checkbox not found (auto)")
         else:
-            # ユーザがチェックボックスをクリックするまで待つ
+            # Wait for the user to click the checkbox
             try:
                 chk_box = WebDriverWait(app.driver, 5).until(
                     EC.presence_of_element_located((By.ID, "demo-human"))

--- a/speedtest_z/sites/ookla.py
+++ b/speedtest_z/sites/ookla.py
@@ -50,7 +50,7 @@ def run_ookla(app: SpeedtestZ) -> None:
                 except TimeoutException:
                     logger.debug("ookla: Consent dialog not found (auto)")
             else:
-                # バナーが出ていたらユーザが「Continue」をクリックするまで待つ
+                # If a banner is shown, wait for the user to click "Continue"
                 try:
                     banner = WebDriverWait(app.driver, 5).until(
                         EC.visibility_of_element_located((By.ID, "onetrust-banner-sdk"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-"""speedtest-z テスト用共通フィクスチャ"""
+"""Shared fixtures for speedtest-z tests."""
 
 import argparse
 import configparser
@@ -12,7 +12,7 @@ from speedtest_z.sender import SenderManager
 
 @pytest.fixture
 def mock_args():
-    """CLI 引数のモック"""
+    """Mock of the CLI arguments."""
     return argparse.Namespace(
         config=None,
         dry_run=False,
@@ -27,7 +27,7 @@ def mock_args():
 
 @pytest.fixture
 def mock_config():
-    """ConfigParser のモック（config.ini-sample 相当）"""
+    """Mock ConfigParser (equivalent to config.ini-sample)."""
     config = configparser.ConfigParser()
     config.read_dict(
         {
@@ -62,7 +62,7 @@ def mock_config():
 
 @pytest.fixture
 def sample_config_ini(tmp_path):
-    """tmp_path に config.ini を作成して返す"""
+    """Create a config.ini under tmp_path and return it."""
     ini = tmp_path / "config.ini"
     ini.write_text(
         "[general]\n"
@@ -84,7 +84,7 @@ def sample_config_ini(tmp_path):
 
 @pytest.fixture
 def mock_driver():
-    """Selenium WebDriver のモック"""
+    """Mock of the Selenium WebDriver."""
     driver = MagicMock()
     driver.page_source = "<html></html>"
     return driver
@@ -92,7 +92,7 @@ def mock_driver():
 
 @pytest.fixture
 def mock_app(mock_config, mock_driver):
-    """SpeedtestZ インスタンスのモック（WebDriver 迂回）"""
+    """Mock SpeedtestZ instance (WebDriver bypassed)."""
     with patch.object(SpeedtestZ, "__init__", lambda self, *a, **kw: None):
         app = SpeedtestZ.__new__(SpeedtestZ)
         app.config = mock_config

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,4 @@
-"""CLI パーサーのテスト"""
+"""Tests for the CLI parser."""
 
 from unittest.mock import MagicMock, patch
 
@@ -14,10 +14,10 @@ from speedtest_z.sites import AVAILABLE_SITES
 
 
 class TestBuildParser:
-    """_build_parser() のテスト"""
+    """Tests for _build_parser()."""
 
     def test_default_args(self):
-        """デフォルト引数の確認"""
+        """Check the default arguments."""
         parser = _build_parser()
         args = parser.parse_args([])
         assert args.config is None
@@ -30,126 +30,126 @@ class TestBuildParser:
         assert args.sites == []
 
     def test_dry_run(self):
-        """-n で dry_run=True"""
+        """-n sets dry_run=True."""
         parser = _build_parser()
         args = parser.parse_args(["-n"])
         assert args.dry_run is True
 
     def test_dry_run_long(self):
-        """--dry-run でも同様"""
+        """--dry-run behaves the same."""
         parser = _build_parser()
         args = parser.parse_args(["--dry-run"])
         assert args.dry_run is True
 
     def test_headless(self):
-        """--headless で headless=True"""
+        """--headless sets headless=True."""
         parser = _build_parser()
         args = parser.parse_args(["--headless"])
         assert args.headless is True
 
     def test_no_headless(self):
-        """--no-headless で headless=False"""
+        """--no-headless sets headless=False."""
         parser = _build_parser()
         args = parser.parse_args(["--no-headless"])
         assert args.headless is False
 
     def test_headed_alias(self):
-        """--headed は --no-headless のエイリアス"""
+        """--headed is an alias for --no-headless."""
         parser = _build_parser()
         args = parser.parse_args(["--headed"])
         assert args.headless is False
 
     def test_timeout(self):
-        """--timeout でタイムアウト設定"""
+        """--timeout sets the timeout."""
         parser = _build_parser()
         args = parser.parse_args(["--timeout", "60"])
         assert args.timeout == 60
 
     def test_config_path(self):
-        """-c で設定ファイルパス指定"""
+        """-c specifies the config file path."""
         parser = _build_parser()
         args = parser.parse_args(["-c", "/tmp/my.ini"])
         assert args.config == "/tmp/my.ini"
 
     def test_debug(self):
-        """-d でデバッグモード"""
+        """-d enables debug mode."""
         parser = _build_parser()
         args = parser.parse_args(["-d"])
         assert args.debug is True
 
     def test_single_site(self):
-        """サイト名を1つ指定"""
+        """Specify a single site name."""
         parser = _build_parser()
         args = parser.parse_args(["cloudflare"])
         assert args.sites == ["cloudflare"]
 
     def test_multiple_sites(self):
-        """サイト名を複数指定"""
+        """Specify multiple site names."""
         parser = _build_parser()
         args = parser.parse_args(["cloudflare", "netflix"])
         assert args.sites == ["cloudflare", "netflix"]
 
     def test_list_sites_flag(self):
-        """--list-sites フラグ"""
+        """--list-sites flag."""
         parser = _build_parser()
         args = parser.parse_args(["--list-sites"])
         assert args.list_sites is True
 
     def test_epilog_contains_github_url(self):
-        """epilog に GitHub URL が含まれること"""
+        """The epilog should contain the GitHub URL."""
         parser = _build_parser()
         assert "https://github.com/shigechika/speedtest-z" in parser.epilog
 
     def test_man_flag(self):
-        """-m で man=True"""
+        """-m sets man=True."""
         parser = _build_parser()
         args = parser.parse_args(["-m"])
         assert args.man is True
 
     def test_man_long_flag(self):
-        """--man でも同様"""
+        """--man behaves the same."""
         parser = _build_parser()
         args = parser.parse_args(["--man"])
         assert args.man is True
 
     def test_man_default_false(self):
-        """デフォルトで man=False"""
+        """man defaults to False."""
         parser = _build_parser()
         args = parser.parse_args([])
         assert args.man is False
 
     def test_yes_short(self):
-        """-y で yes=True"""
+        """-y sets yes=True."""
         parser = _build_parser()
         args = parser.parse_args(["-y"])
         assert args.yes is True
 
     def test_yes_long(self):
-        """--yes でも同様"""
+        """--yes behaves the same."""
         parser = _build_parser()
         args = parser.parse_args(["--yes"])
         assert args.yes is True
 
 
 class TestShowManual:
-    """_show_manual() のテスト"""
+    """Tests for _show_manual()."""
 
     def test_manual_text_contains_speedtest(self):
-        """マニュアルテキストに speedtest-z が含まれること"""
+        """The manual text should contain speedtest-z."""
         with patch("pydoc.pager") as mock_pager:
             _show_manual()
             text = mock_pager.call_args[0][0]
             assert "speedtest-z" in text
 
     def test_manual_japanese_locale(self):
-        """日本語ロケールで README.ja.md が表示されること"""
+        """README.ja.md is shown in a Japanese locale."""
         with patch("pydoc.pager") as mock_pager, patch("speedtest_z.cli._LANG_JA", True):
             _show_manual()
             text = mock_pager.call_args[0][0]
             assert "特徴" in text
 
     def test_manual_english_locale(self):
-        """英語ロケールで README.md が表示されること"""
+        """README.md is shown in an English locale."""
         with patch("pydoc.pager") as mock_pager, patch("speedtest_z.cli._LANG_JA", False):
             _show_manual()
             text = mock_pager.call_args[0][0]
@@ -157,10 +157,10 @@ class TestShowManual:
 
 
 class TestMainMan:
-    """main() の --man 分岐テスト"""
+    """Tests for the --man branch of main()."""
 
     def test_man_calls_show_manual(self):
-        """--man で _show_manual() が呼ばれること"""
+        """--man should call _show_manual()."""
         with (
             patch("speedtest_z.cli._build_parser") as mock_parser,
             patch("speedtest_z.cli._show_manual") as mock_show,
@@ -174,10 +174,10 @@ class TestMainMan:
 
 
 class TestMainListSites:
-    """main() の --list-sites 分岐テスト"""
+    """Tests for the --list-sites branch of main()."""
 
     def test_list_sites_output(self, capsys):
-        """--list-sites でサイト一覧を出力して終了"""
+        """--list-sites prints the site list and exits."""
         with patch("speedtest_z.cli._build_parser") as mock_parser:
             mock_args = MagicMock()
             mock_args.man = False
@@ -192,10 +192,10 @@ class TestMainListSites:
 
 
 class TestMainConfigRequired:
-    """main() の config.ini 必須チェックテスト"""
+    """Tests that main() requires config.ini."""
 
     def test_exit_when_config_not_found(self):
-        """config.ini が見つからない場合 sys.exit(1)"""
+        """sys.exit(1) when config.ini is not found."""
         with (
             patch("speedtest_z.cli._build_parser") as mock_parser,
             patch("speedtest_z.cli._setup_logging"),
@@ -213,7 +213,7 @@ class TestMainConfigRequired:
             assert exc_info.value.code == 1
 
     def test_config_path_passed_to_speedtestz(self):
-        """見つかった config パスが args.config に設定されること"""
+        """The discovered config path is set on args.config."""
         with (
             patch("speedtest_z.cli._build_parser") as mock_parser,
             patch("speedtest_z.cli._setup_logging"),
@@ -231,7 +231,7 @@ class TestMainConfigRequired:
             mock_args.yes = True
             mock_args.sites = []
             mock_parser.return_value.parse_args.return_value = mock_args
-            # SpeedtestZ のインスタンスもモック
+            # Also mock the SpeedtestZ instance.
             mock_app = MagicMock()
             mock_stz.return_value = mock_app
             mock_stdin.isatty.return_value = False
@@ -241,10 +241,10 @@ class TestMainConfigRequired:
 
 
 class TestMainConfirmPrompt:
-    """main() の確認プロンプトテスト"""
+    """Tests for the confirmation prompt in main()."""
 
     def _make_args(self, yes=False, sites=None):
-        """テスト用の mock args を生成"""
+        """Build mock args for tests."""
         mock_args = MagicMock()
         mock_args.man = False
         mock_args.list_sites = False
@@ -256,7 +256,7 @@ class TestMainConfirmPrompt:
         return mock_args
 
     def test_prompt_shown_on_tty(self, capsys):
-        """TTY で --yes なしの場合、確認プロンプトが表示されること"""
+        """The confirmation prompt is shown on a TTY without --yes."""
         with (
             patch("speedtest_z.cli._build_parser") as mock_parser,
             patch("speedtest_z.cli._setup_logging"),
@@ -269,11 +269,11 @@ class TestMainConfirmPrompt:
             mock_stdin.isatty.return_value = True
             main()
         captured = capsys.readouterr()
-        # ロケールに依存しないアサーション
+        # Locale-independent assertion.
         assert _msg("confirm_abort") in captured.out
 
     def test_prompt_yes_continues(self):
-        """確認プロンプトで y を入力すると続行されること"""
+        """Entering y at the confirmation prompt continues."""
         with (
             patch("speedtest_z.cli._build_parser") as mock_parser,
             patch("speedtest_z.cli._setup_logging"),
@@ -292,7 +292,7 @@ class TestMainConfirmPrompt:
             mock_stz.assert_called_once()
 
     def test_prompt_shown_with_yes_flag(self):
-        """--yes フラグでも TTY なら確認プロンプトが表示されること"""
+        """The confirmation prompt is still shown on a TTY even with --yes."""
         with (
             patch("speedtest_z.cli._build_parser") as mock_parser,
             patch("speedtest_z.cli._setup_logging"),
@@ -312,7 +312,7 @@ class TestMainConfirmPrompt:
             mock_stz.assert_called_once()
 
     def test_prompt_skipped_on_non_tty(self):
-        """非 TTY（パイプ/cron）ではプロンプトが表示されないこと"""
+        """The prompt is not shown on a non-TTY (pipe/cron)."""
         with (
             patch("speedtest_z.cli._build_parser") as mock_parser,
             patch("speedtest_z.cli._setup_logging"),
@@ -332,7 +332,7 @@ class TestMainConfirmPrompt:
             mock_stz.assert_called_once()
 
     def test_prompt_shows_specified_sites(self, capsys):
-        """サイト指定時、指定サイトがプロンプトに表示されること"""
+        """When sites are specified, they appear in the prompt."""
         with (
             patch("speedtest_z.cli._build_parser") as mock_parser,
             patch("speedtest_z.cli._setup_logging"),
@@ -348,7 +348,7 @@ class TestMainConfirmPrompt:
         assert "cloudflare, netflix" in captured.out
 
     def test_prompt_abort_with_empty_input(self, capsys):
-        """空入力（Enter のみ）で中止されること"""
+        """Empty input (just Enter) aborts."""
         with (
             patch("speedtest_z.cli._build_parser") as mock_parser,
             patch("speedtest_z.cli._setup_logging"),
@@ -405,48 +405,48 @@ class TestMainFatalExit:
 
 
 class TestI18nMessages:
-    """_msg() の日英切り替えテスト"""
+    """Tests for _msg() switching between Japanese and English."""
 
     def test_msg_japanese(self):
-        """_LANG_JA=True で日本語メッセージが返ること"""
+        """_LANG_JA=True returns Japanese messages."""
         with patch("speedtest_z.i18n._LANG_JA", True):
             assert _msg("confirm_abort") == "中止しました。"
             assert _msg("manual_not_found") == "マニュアルが見つかりません。"
 
     def test_msg_english(self):
-        """_LANG_JA=False で英語メッセージが返ること"""
+        """_LANG_JA=False returns English messages."""
         with patch("speedtest_z.i18n._LANG_JA", False):
             assert _msg("confirm_abort") == "Aborted."
             assert _msg("manual_not_found") == "Manual not found."
 
     def test_msg_with_kwargs_japanese(self):
-        """日本語メッセージのフォーマット引数が展開されること"""
+        """Format arguments are expanded in a Japanese message."""
         with patch("speedtest_z.i18n._LANG_JA", True):
             result = _msg("config_not_found_cli", path="/tmp/test.ini")
             assert result == "/tmp/test.ini が見つかりません"
 
     def test_msg_with_kwargs_english(self):
-        """英語メッセージのフォーマット引数が展開されること"""
+        """Format arguments are expanded in an English message."""
         with patch("speedtest_z.i18n._LANG_JA", False):
             result = _msg("config_not_found_cli", path="/tmp/test.ini")
             assert result == "/tmp/test.ini not found"
 
     def test_confirm_prompt_japanese(self):
-        """日本語の確認プロンプトメッセージ"""
+        """The Japanese confirmation prompt message."""
         with patch("speedtest_z.i18n._LANG_JA", True):
             result = _msg("confirm_prompt", count=2, sites="cloudflare, netflix")
             assert "2 サイトに接続します" in result
             assert "cloudflare, netflix" in result
 
     def test_confirm_prompt_english(self):
-        """英語の確認プロンプトメッセージ"""
+        """The English confirmation prompt message."""
         with patch("speedtest_z.i18n._LANG_JA", False):
             result = _msg("confirm_prompt", count=2, sites="cloudflare, netflix")
             assert "connecting to 2 site(s)" in result
             assert "cloudflare, netflix" in result
 
     def test_prompt_shown_japanese(self, capsys):
-        """日本語ロケールで日本語プロンプトが表示されること"""
+        """The Japanese prompt is shown in a Japanese locale."""
         with (
             patch("speedtest_z.cli._build_parser") as mock_parser,
             patch("speedtest_z.cli._setup_logging"),
@@ -471,7 +471,7 @@ class TestI18nMessages:
         assert "中止しました。" in captured.out
 
     def test_prompt_shown_english(self, capsys):
-        """英語ロケールで英語プロンプトが表示されること"""
+        """The English prompt is shown in an English locale."""
         with (
             patch("speedtest_z.cli._build_parser") as mock_parser,
             patch("speedtest_z.cli._setup_logging"),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,4 @@
-"""設定ファイル探索のテスト"""
+"""Tests for config file discovery."""
 
 import logging
 import os
@@ -14,39 +14,39 @@ from speedtest_z.runner import SpeedtestZ
 
 
 class TestFindConfig:
-    """_find_config() のテスト"""
+    """Tests for _find_config()."""
 
     def test_cli_path_exists(self, tmp_path):
-        """CLI で指定したパスにファイルがあれば返す"""
+        """Return the CLI-specified path if the file exists."""
         f = tmp_path / "my.ini"
         f.write_text("[general]\n")
         assert _find_config("config.ini", cli_path=str(f)) == str(f)
 
     def test_cli_path_not_exists(self, tmp_path):
-        """CLI で指定したパスにファイルがなければ None"""
+        """None if the CLI-specified path does not exist."""
         result = _find_config("config.ini", cli_path=str(tmp_path / "no.ini"))
         assert result is None
 
     def test_current_dir(self, tmp_path, monkeypatch):
-        """カレントディレクトリの config.ini を検出"""
+        """Detect config.ini in the current directory."""
         (tmp_path / "config.ini").write_text("[general]\n")
         monkeypatch.chdir(tmp_path)
         assert _find_config("config.ini") == "config.ini"
 
     def test_xdg_config_home(self, tmp_path, monkeypatch):
-        """XDG_CONFIG_HOME 配下を検出"""
+        """Detect config under XDG_CONFIG_HOME."""
         xdg = tmp_path / "xdg"
         conf_dir = xdg / "speedtest-z"
         conf_dir.mkdir(parents=True)
         (conf_dir / "config.ini").write_text("[general]\n")
 
         monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg))
-        # カレントに config.ini がないディレクトリへ移動
+        # Move to a directory that has no config.ini in CWD.
         monkeypatch.chdir(tmp_path)
         assert _find_config("config.ini") == str(conf_dir / "config.ini")
 
     def test_xdg_default(self, tmp_path, monkeypatch):
-        """XDG_CONFIG_HOME 未設定時は ~/.config を使う"""
+        """Use ~/.config when XDG_CONFIG_HOME is unset."""
         fake_home = tmp_path / "home"
         conf_dir = fake_home / ".config" / "speedtest-z"
         conf_dir.mkdir(parents=True)
@@ -70,13 +70,13 @@ class TestFindConfig:
         assert _find_config("config.ini") == str(conf_dir / "config.ini")
 
     def test_etc_fallback(self, tmp_path, monkeypatch):
-        """/etc/speedtest-z/ にフォールバック"""
+        """Fall back to /etc/speedtest-z/."""
         monkeypatch.chdir(tmp_path)
         monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
         etc_dir = tmp_path / "etc" / "speedtest-z"
         etc_dir.mkdir(parents=True)
         (etc_dir / "config.ini").write_text("[general]\n")
-        # os.path.isfile を差し替えて /etc/speedtest-z/ をシミュレート
+        # Patch os.path.isfile to simulate /etc/speedtest-z/.
         _real_isfile = os.path.isfile
 
         def patched_isfile(path):
@@ -88,14 +88,14 @@ class TestFindConfig:
         assert _find_config("config.ini") == "/etc/speedtest-z/config.ini"
 
     def test_cwd_over_etc(self, tmp_path, monkeypatch):
-        """CWD は /etc/speedtest-z/ より優先"""
+        """CWD takes priority over /etc/speedtest-z/."""
         (tmp_path / "config.ini").write_text("[general]\n")
         monkeypatch.chdir(tmp_path)
-        # /etc にもあっても CWD が優先される
+        # CWD wins even if /etc also has one.
         assert _find_config("config.ini") == "config.ini"
 
     def test_xdg_over_etc(self, tmp_path, monkeypatch):
-        """XDG は /etc/speedtest-z/ より優先"""
+        """XDG takes priority over /etc/speedtest-z/."""
         xdg = tmp_path / "xdg"
         conf_dir = xdg / "speedtest-z"
         conf_dir.mkdir(parents=True)
@@ -105,13 +105,13 @@ class TestFindConfig:
         assert _find_config("config.ini") == str(conf_dir / "config.ini")
 
     def test_not_found(self, tmp_path, monkeypatch):
-        """どこにもなければ None"""
+        """None if not found anywhere."""
         monkeypatch.chdir(tmp_path)
         monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
         assert _find_config("config.ini") is None
 
     def test_cli_path_takes_priority(self, tmp_path, monkeypatch):
-        """CLI 指定はカレントディレクトリより優先"""
+        """A CLI-specified path takes priority over the current directory."""
         (tmp_path / "config.ini").write_text("[cwd]\n")
         cli_file = tmp_path / "cli.ini"
         cli_file.write_text("[cli]\n")
@@ -120,17 +120,17 @@ class TestFindConfig:
         assert _find_config("config.ini", cli_path=str(cli_file)) == str(cli_file)
 
     def test_logging_ini(self, tmp_path, monkeypatch):
-        """logging.ini も同じ探索ロジックで見つかる"""
+        """logging.ini is found via the same discovery logic."""
         (tmp_path / "logging.ini").write_text("[loggers]\n")
         monkeypatch.chdir(tmp_path)
         assert _find_config("logging.ini") == "logging.ini"
 
 
 class TestSetupLogging:
-    """_setup_logging() のテスト"""
+    """Tests for _setup_logging()."""
 
     def test_no_logging_ini(self, tmp_path, monkeypatch):
-        """logging.ini がなければ basicConfig で初期化"""
+        """Initialize via basicConfig when there is no logging.ini."""
         monkeypatch.chdir(tmp_path)
         monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
         with patch("speedtest_z.config.logging.basicConfig") as mock_basic:
@@ -138,7 +138,7 @@ class TestSetupLogging:
             mock_basic.assert_called_once()
 
     def test_debug_mode(self, tmp_path, monkeypatch):
-        """debug=True で DEBUG レベルに設定"""
+        """debug=True sets the DEBUG level."""
         monkeypatch.chdir(tmp_path)
         monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
         with patch("speedtest_z.config.logging.basicConfig") as mock_basic:
@@ -184,17 +184,17 @@ class TestSetupLogging:
 
 
 class TestChromeProfileDir:
-    """chrome_profile_dir 設定のテスト"""
+    """Tests for the chrome_profile_dir setting."""
 
     def _make_app(self, mock_config):
-        """WebDriver を迂回して SpeedtestZ インスタンスを作成"""
+        """Create a SpeedtestZ instance, bypassing the WebDriver."""
         with patch.object(SpeedtestZ, "__init__", lambda self, *a, **kw: None):
             app = SpeedtestZ.__new__(SpeedtestZ)
             app.config = mock_config
         return app
 
     def test_default_path(self, mock_config):
-        """デフォルトで ~/.config/speedtest-z/chrome-profile が設定される"""
+        """Defaults to ~/.config/speedtest-z/chrome-profile."""
         app = self._make_app(mock_config)
         app.chrome_profile_dir = os.path.expanduser(
             app.config.get(
@@ -205,7 +205,7 @@ class TestChromeProfileDir:
         assert app.chrome_profile_dir == expected
 
     def test_custom_path(self, mock_config):
-        """config でカスタムパスを指定"""
+        """Specify a custom path via config."""
         mock_config.set("general", "chrome_profile_dir", "/tmp/my-chrome-profile")
         app = self._make_app(mock_config)
         app.chrome_profile_dir = os.path.expanduser(
@@ -216,7 +216,7 @@ class TestChromeProfileDir:
         assert app.chrome_profile_dir == "/tmp/my-chrome-profile"
 
     def test_tilde_expansion(self, mock_config):
-        """~ がホームディレクトリに展開される"""
+        """~ is expanded to the home directory."""
         mock_config.set("general", "chrome_profile_dir", "~/my-profile")
         app = self._make_app(mock_config)
         app.chrome_profile_dir = os.path.expanduser(

--- a/tests/test_consent.py
+++ b/tests/test_consent.py
@@ -1,4 +1,4 @@
-"""auto_consent（--yes による同意自動承諾）のテスト"""
+"""Tests for auto_consent (auto-approving consent via --yes)."""
 
 import argparse
 from unittest.mock import patch
@@ -7,7 +7,7 @@ from speedtest_z.runner import SpeedtestZ
 
 
 def _make_app(mock_config, yes=False):
-    """WebDriver を迂回して SpeedtestZ インスタンスを作成"""
+    """Create a SpeedtestZ instance, bypassing the WebDriver."""
     with patch.object(SpeedtestZ, "__init__", lambda self, *a, **kw: None):
         app = SpeedtestZ.__new__(SpeedtestZ)
         app.config = mock_config
@@ -16,20 +16,20 @@ def _make_app(mock_config, yes=False):
 
 
 class TestAutoConsent:
-    """auto_consent フラグの伝播テスト"""
+    """Tests for propagation of the auto_consent flag."""
 
     def test_default_false(self, mock_config):
-        """デフォルトで auto_consent=False"""
+        """auto_consent defaults to False."""
         app = _make_app(mock_config)
         assert app.auto_consent is False
 
     def test_yes_flag_sets_true(self, mock_config):
-        """yes=True で auto_consent=True"""
+        """yes=True sets auto_consent=True."""
         app = _make_app(mock_config, yes=True)
         assert app.auto_consent is True
 
     def test_init_with_yes_arg(self, mock_config, sample_config_ini):
-        """SpeedtestZ.__init__ に --yes 付き args を渡すと auto_consent=True"""
+        """Passing args with --yes to SpeedtestZ.__init__ sets auto_consent=True."""
         args = argparse.Namespace(
             config=str(sample_config_ini),
             dry_run=True,
@@ -45,7 +45,7 @@ class TestAutoConsent:
         assert app.auto_consent is True
 
     def test_init_without_yes_arg(self, mock_config, sample_config_ini):
-        """SpeedtestZ.__init__ に --yes なし args を渡すと auto_consent=False"""
+        """Passing args without --yes to SpeedtestZ.__init__ sets auto_consent=False."""
         args = argparse.Namespace(
             config=str(sample_config_ini),
             dry_run=True,
@@ -61,7 +61,7 @@ class TestAutoConsent:
         assert app.auto_consent is False
 
     def test_init_without_yes_attr(self, mock_config, sample_config_ini):
-        """args に yes 属性がない場合でも auto_consent=False（getattr フォールバック）"""
+        """auto_consent=False even when args has no yes attribute (getattr fallback)."""
         args = argparse.Namespace(
             config=str(sample_config_ini),
             dry_run=True,

--- a/tests/test_grafana.py
+++ b/tests/test_grafana.py
@@ -1,4 +1,4 @@
-"""Grafana Cloud 統合のテスト"""
+"""Tests for the Grafana Cloud integration."""
 
 import configparser
 import io
@@ -91,11 +91,11 @@ def _decode_write_request(data):
     return series
 
 
-# --- Protobuf エンコーダーのユニットテスト ---
+# --- Unit tests for the Protobuf encoders ---
 
 
 class TestEncodeVarint:
-    """_encode_varint() のテスト"""
+    """Tests for _encode_varint()."""
 
     def test_zero(self):
         assert _encode_varint(0) == b"\x00"
@@ -110,60 +110,60 @@ class TestEncodeVarint:
 
 
 class TestEncodeFields:
-    """各 Protobuf フィールドエンコーダーのテスト"""
+    """Tests for each Protobuf field encoder."""
 
     def test_encode_string(self):
-        """文字列が正しくエンコードされること"""
+        """A string is encoded correctly."""
         result = _encode_string(1, "test")
         # field 1, wire type 2 (length-delimited) = tag 0x0a
         assert result[0:1] == b"\x0a"
         assert b"test" in result
 
     def test_encode_double(self):
-        """double が正しくエンコードされること"""
+        """A double is encoded correctly."""
         result = _encode_double(1, 3.14)
         # field 1, wire type 1 (64-bit) = tag 0x09
         assert result[0:1] == b"\x09"
-        # 値の検証
+        # Verify the value
         value = struct.unpack("<d", result[1:])[0]
         assert abs(value - 3.14) < 1e-10
 
     def test_encode_int64(self):
-        """int64 が正しくエンコードされること"""
+        """An int64 is encoded correctly."""
         result = _encode_int64(2, 1000)
         # field 2, wire type 0 (varint) = tag 0x10
         assert result[0:1] == b"\x10"
 
     def test_encode_bytes(self):
-        """bytes が正しくエンコードされること"""
+        """Bytes are encoded correctly."""
         result = _encode_bytes(1, b"hello")
         assert b"hello" in result
 
 
 class TestEncodeLabel:
-    """encode_label() のテスト"""
+    """Tests for encode_label()."""
 
     def test_basic(self):
-        """ラベルのエンコード結果に name と value が含まれること"""
+        """The encoded label contains both name and value."""
         result = encode_label("__name__", "speedtest_download")
         assert b"__name__" in result
         assert b"speedtest_download" in result
 
 
 class TestEncodeSample:
-    """encode_sample() のテスト"""
+    """Tests for encode_sample()."""
 
     def test_basic(self):
-        """サンプルが正しくエンコードされること"""
+        """A sample is encoded correctly."""
         result = encode_sample(100.5, 1700000000000)
         assert len(result) > 0
 
 
 class TestEncodeTimeseries:
-    """encode_timeseries() のテスト"""
+    """Tests for encode_timeseries()."""
 
     def test_basic(self):
-        """TimeSeries が正しくエンコードされること"""
+        """A TimeSeries is encoded correctly."""
         labels = [("__name__", "speedtest_download"), ("site", "cloudflare")]
         result = encode_timeseries(labels, 100.5, 1700000000000)
         assert b"speedtest_download" in result
@@ -171,16 +171,16 @@ class TestEncodeTimeseries:
 
 
 class TestEncodeWriteRequest:
-    """encode_write_request() のテスト"""
+    """Tests for encode_write_request()."""
 
     def test_single(self):
-        """単一 TimeSeries の WriteRequest"""
+        """WriteRequest with a single TimeSeries."""
         ts = encode_timeseries([("__name__", "speedtest_download")], 100.5, 1700000000000)
         result = encode_write_request([ts])
         assert len(result) > 0
 
     def test_multiple(self):
-        """複数 TimeSeries の WriteRequest"""
+        """WriteRequest with multiple TimeSeries."""
         ts1 = encode_timeseries([("__name__", "speedtest_download")], 100.5, 1700000000000)
         ts2 = encode_timeseries([("__name__", "speedtest_upload")], 50.2, 1700000000000)
         result = encode_write_request([ts1, ts2])
@@ -228,21 +228,21 @@ class TestEncoderRoundTrip:
         assert series[1]["samples"][0][1] == 1700000000001
 
 
-# --- GrafanaSender のテスト ---
+# --- Tests for GrafanaSender ---
 
 
 class TestGrafanaSender:
-    """GrafanaSender のテスト"""
+    """Tests for GrafanaSender."""
 
     def test_init(self):
-        """初期化で属性が設定されること"""
+        """Attributes are set during initialization."""
         sender = GrafanaSender("https://example.com/push", "user", "token")
         assert sender.url == "https://example.com/push"
         assert sender.username == "user"
         assert sender.token == "token"
 
     def _mock_cramjam(self):
-        """cramjam モジュールのモックを返す"""
+        """Return a mock of the cramjam module."""
         mock_cramjam = MagicMock()
         mock_cramjam.snappy.compress_raw.return_value = b"compressed"
         return mock_cramjam
@@ -259,7 +259,7 @@ class TestGrafanaSender:
         return mock_opener
 
     def test_send_numeric_values(self):
-        """数値メトリクスが送信されること"""
+        """Numeric metrics are sent."""
         sender = GrafanaSender("https://example.com/push", "user", "token")
         data = [
             {"key": "cloudflare.download", "value": "100.5", "host": "test-host"},
@@ -273,7 +273,7 @@ class TestGrafanaSender:
             sender.send(data)
             mock_opener.open.assert_called_once()
 
-            # HTTP リクエストの検証
+            # Verify the HTTP request
             req = mock_opener.open.call_args[0][0]
             assert req.get_header("Content-type") == "application/x-protobuf"
             assert req.get_header("Content-encoding") == "snappy"
@@ -282,7 +282,7 @@ class TestGrafanaSender:
             assert "Authorization" in req.unredirected_hdrs
 
     def test_send_skips_non_numeric(self):
-        """数値でない値はスキップされること"""
+        """Non-numeric values are skipped."""
         sender = GrafanaSender("https://example.com/push", "user", "token")
         data = [
             {"key": "netflix.server-locations", "value": "Tokyo, Osaka"},
@@ -298,7 +298,7 @@ class TestGrafanaSender:
             mock_opener.open.assert_not_called()
 
     def test_send_skips_invalid_key(self):
-        """ドットなしの key はスキップされること"""
+        """A key without a dot is skipped."""
         sender = GrafanaSender("https://example.com/push", "user", "token")
         data = [{"key": "invalid_key", "value": "100.5"}]
         mock_opener = self._mock_opener()
@@ -310,7 +310,7 @@ class TestGrafanaSender:
             mock_opener.open.assert_not_called()
 
     def test_send_mixed_values(self):
-        """数値と非数値が混在する場合、数値のみ送信されること"""
+        """When numeric and non-numeric values are mixed, only the numeric ones are sent."""
         sender = GrafanaSender("https://example.com/push", "user", "token")
         data = [
             {"key": "cloudflare.download", "value": "100.5", "host": "test"},
@@ -366,20 +366,20 @@ class TestGrafanaSender:
             sender.send(data)
 
 
-# --- cramjam 未インストール時のフォールバックテスト ---
+# --- Fallback tests for when cramjam is not installed ---
 
 
 class TestCramjamFallback:
-    """cramjam 未インストール時の graceful fallback テスト"""
+    """Graceful fallback tests for when cramjam is not installed."""
 
     def test_grafana_init_without_cramjam(self):
-        """cramjam なしでも GrafanaSender の初期化でエラーにならないこと"""
-        # GrafanaSender 自体は cramjam を import しない（send() 時に import）
+        """Initializing GrafanaSender does not error even without cramjam."""
+        # GrafanaSender itself does not import cramjam (it imports it inside send())
         sender = GrafanaSender("https://example.com/push", "user", "token")
         assert sender is not None
 
     def test_runner_grafana_without_cramjam(self):
-        """cramjam なしで [grafana] enable=true の場合、警告が出ること"""
+        """A warning is emitted when [grafana] enable=true but cramjam is missing."""
         config = configparser.ConfigParser()
         config.read_dict(
             {
@@ -412,7 +412,7 @@ class TestCramjamFallback:
             app.config = config
             app.dryrun = True
             app.grafana_sender = None
-            # [grafana] セクションの読み込みをシミュレート
+            # Simulate loading the [grafana] section
             if config.has_section("grafana"):
                 grafana_enable = config.getboolean("grafana", "enable", fallback=False)
                 if grafana_enable:
@@ -423,11 +423,11 @@ class TestCramjamFallback:
             assert app.grafana_sender is None
 
 
-# --- send_results() の統合テスト ---
+# --- Integration tests for send_results() ---
 
 
 def _make_sender(dryrun=True, zabbix_enable=False, grafana_sender=None):
-    """SenderManager インスタンスを直接作成"""
+    """Create a SenderManager instance directly."""
     with patch.object(SenderManager, "__init__", lambda self, *a, **kw: None):
         sender = SenderManager.__new__(SenderManager)
         sender.dry_run = dryrun
@@ -441,10 +441,10 @@ def _make_sender(dryrun=True, zabbix_enable=False, grafana_sender=None):
 
 
 class TestSendResultsZabbixEnable:
-    """[zabbix] enable フラグのテスト"""
+    """Tests for the [zabbix] enable flag."""
 
     def test_zabbix_disabled_no_send(self):
-        """zabbix_enable=False では Sender が呼ばれないこと"""
+        """Sender is not called when zabbix_enable=False."""
         sender = _make_sender(dryrun=False, zabbix_enable=False)
         data = [{"key": "speedtest.dl", "value": "100.5"}]
         with patch("speedtest_z.sender.Sender") as mock_sender:
@@ -452,7 +452,7 @@ class TestSendResultsZabbixEnable:
             mock_sender.assert_not_called()
 
     def test_zabbix_enabled_sends(self):
-        """zabbix_enable=True では Sender.send_bulk() が呼ばれること"""
+        """Sender.send_bulk() is called when zabbix_enable=True."""
         sender = _make_sender(dryrun=False, zabbix_enable=True)
         data = [{"key": "speedtest.dl", "value": "100.5"}]
         with patch("speedtest_z.sender.Sender") as mock_sender_cls:
@@ -464,10 +464,10 @@ class TestSendResultsZabbixEnable:
 
 
 class TestSendResultsGrafana:
-    """send_results() の Grafana 送信テスト"""
+    """Grafana send tests for send_results()."""
 
     def test_grafana_sender_called(self):
-        """grafana_sender が設定されていれば send() が呼ばれること"""
+        """send() is called when grafana_sender is set."""
         mock_grafana = MagicMock()
         sender = _make_sender(dryrun=False, grafana_sender=mock_grafana)
         data = [{"key": "cloudflare.download", "value": "100.5"}]
@@ -476,7 +476,7 @@ class TestSendResultsGrafana:
             mock_grafana.send.assert_called_once_with(data)
 
     def test_grafana_sender_not_called_on_dryrun(self):
-        """dryrun=True では grafana_sender.send() が呼ばれないこと"""
+        """grafana_sender.send() is not called when dryrun=True."""
         mock_grafana = MagicMock()
         sender = _make_sender(dryrun=True, grafana_sender=mock_grafana)
         data = [{"key": "cloudflare.download", "value": "100.5"}]
@@ -484,16 +484,16 @@ class TestSendResultsGrafana:
         mock_grafana.send.assert_not_called()
 
     def test_grafana_error_handled(self):
-        """Grafana 送信エラーでもクラッシュしないこと"""
+        """A Grafana send error does not crash the run."""
         mock_grafana = MagicMock()
         mock_grafana.send.side_effect = Exception("Connection error")
         sender = _make_sender(dryrun=False, grafana_sender=mock_grafana)
         data = [{"key": "cloudflare.download", "value": "100.5"}]
         with patch("speedtest_z.sender.Sender"):
-            sender.send(data)  # 例外が伝播しない
+            sender.send(data)  # the exception does not propagate
 
     def test_both_zabbix_and_grafana(self):
-        """Zabbix と Grafana の両方が呼ばれること"""
+        """Both Zabbix and Grafana are called."""
         mock_grafana = MagicMock()
         sender = _make_sender(dryrun=False, zabbix_enable=True, grafana_sender=mock_grafana)
         data = [{"key": "cloudflare.download", "value": "100.5"}]
@@ -505,42 +505,42 @@ class TestSendResultsGrafana:
             mock_grafana.send.assert_called_once_with(data)
 
 
-# --- config.ini の dry_run / dryrun 互換テスト ---
+# --- Compatibility tests for the dry_run / dryrun config keys ---
 
 
 class TestDryRunCompat:
-    """dry_run / dryrun 両方の config キー互換テスト"""
+    """Compatibility tests for both the dry_run and dryrun config keys."""
 
     def _make_app_with_config(self, config_dict):
-        """config 辞書から SpeedtestZ を作成"""
+        """Create a SpeedtestZ from a config dict."""
         config = configparser.ConfigParser()
         config.read_dict(config_dict)
         with patch.object(SpeedtestZ, "__init__", lambda self, *a, **kw: None):
             app = SpeedtestZ.__new__(SpeedtestZ)
             app.config = config
-            # dry_run / dryrun の互換読み込みロジックを再現
+            # Reproduce the dry_run / dryrun compatibility loading logic
             app.dryrun = config.getboolean("general", "dry_run", fallback=None)
             if app.dryrun is None:
                 app.dryrun = config.getboolean("general", "dryrun", fallback=True)
         return app
 
     def test_dry_run_key(self):
-        """dry_run キーが読み込まれること"""
+        """The dry_run key is read."""
         app = self._make_app_with_config({"general": {"dry_run": "false"}})
         assert app.dryrun is False
 
     def test_dryrun_key_fallback(self):
-        """旧名 dryrun キーがフォールバックで読み込まれること"""
+        """The legacy dryrun key is read as a fallback."""
         app = self._make_app_with_config({"general": {"dryrun": "false"}})
         assert app.dryrun is False
 
     def test_dry_run_takes_priority(self):
-        """dry_run と dryrun 両方ある場合、dry_run が優先されること"""
+        """When both dry_run and dryrun are present, dry_run takes priority."""
         app = self._make_app_with_config({"general": {"dry_run": "false", "dryrun": "true"}})
         assert app.dryrun is False
 
     def test_neither_key_defaults_true(self):
-        """どちらもない場合、デフォルト True になること"""
+        """Defaults to True when neither key is present."""
         app = self._make_app_with_config({"general": {"headless": "true"}})
         assert app.dryrun is True
 

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -1,4 +1,4 @@
-"""ヘルスチェック (--check) のテスト"""
+"""Tests for the health check (--check)."""
 
 import urllib.error
 from unittest.mock import MagicMock, patch
@@ -7,10 +7,10 @@ from speedtest_z.healthcheck import SITE_URLS, _check_url, check_sites
 
 
 class TestCheckUrl:
-    """_check_url() のテスト"""
+    """Tests for _check_url()."""
 
     def test_success_head(self):
-        """HEAD 成功時は (200, "OK") を返す"""
+        """Return (200, "OK") when HEAD succeeds."""
         mock_resp = MagicMock()
         mock_resp.status = 200
         mock_resp.reason = "OK"
@@ -23,7 +23,7 @@ class TestCheckUrl:
         assert reason == "OK"
 
     def test_fallback_to_get_on_405(self):
-        """HEAD で 405 の場合は GET にフォールバック"""
+        """Fall back to GET when HEAD returns 405."""
         mock_resp = MagicMock()
         mock_resp.status = 200
         mock_resp.reason = "OK"
@@ -57,7 +57,7 @@ class TestCheckUrl:
         assert status == 200
 
     def test_http_error(self):
-        """HTTP エラー（405以外）は即座にエラーコードを返す"""
+        """HTTP errors (other than 405) immediately return the error code."""
         with patch(
             "speedtest_z.healthcheck.urllib.request.urlopen",
             side_effect=urllib.error.HTTPError("url", 503, "Service Unavailable", {}, None),
@@ -66,7 +66,7 @@ class TestCheckUrl:
         assert status == 503
 
     def test_network_error(self):
-        """ネットワークエラーは (0, エラー文字列) を返す"""
+        """Network errors return (0, error string)."""
         with patch(
             "speedtest_z.healthcheck.urllib.request.urlopen",
             side_effect=Exception("Connection refused"),
@@ -77,10 +77,10 @@ class TestCheckUrl:
 
 
 class TestCheckSites:
-    """check_sites() のテスト"""
+    """Tests for check_sites()."""
 
     def test_all_ok_returns_0(self, capsys):
-        """全サイト OK の場合は 0 を返す"""
+        """Return 0 when all sites are OK."""
         mock_resp = MagicMock()
         mock_resp.status = 200
         mock_resp.reason = "OK"
@@ -92,12 +92,12 @@ class TestCheckSites:
         assert result == 0
         captured = capsys.readouterr()
         assert "Site Health Check:" in captured.out
-        # 全サイトが出力に含まれる
+        # All sites are included in the output
         for site in SITE_URLS:
             assert site in captured.out
 
     def test_failure_returns_1(self, capsys):
-        """1つでも失敗があれば 1 を返す"""
+        """Return 1 if even one site fails."""
         with patch(
             "speedtest_z.healthcheck.urllib.request.urlopen",
             side_effect=Exception("timeout"),
@@ -118,7 +118,7 @@ class TestCheckSites:
         assert "Connection refused" in captured.out
 
     def test_specific_sites(self, capsys):
-        """特定サイトのみチェック"""
+        """Check only specific sites."""
         mock_resp = MagicMock()
         mock_resp.status = 200
         mock_resp.reason = "OK"
@@ -131,28 +131,28 @@ class TestCheckSites:
         captured = capsys.readouterr()
         assert "cloudflare" in captured.out
         assert "netflix" in captured.out
-        # 指定していないサイトは出力されない
+        # Unspecified sites are not in the output
         assert "ookla" not in captured.out
 
     def test_unknown_site(self, capsys):
-        """存在しないサイト名は FAIL"""
+        """An unknown site name results in FAIL."""
         result = check_sites(["nonexistent"])
         assert result == 1
         captured = capsys.readouterr()
         assert "Unknown site" in captured.out
 
     def test_site_urls_has_all_sites(self):
-        """SITE_URLS が AVAILABLE_SITES と一致"""
+        """SITE_URLS matches AVAILABLE_SITES."""
         from speedtest_z.sites import AVAILABLE_SITES
 
         assert set(SITE_URLS.keys()) == set(AVAILABLE_SITES)
 
 
 class TestCliCheckFlag:
-    """CLI --check フラグのテスト"""
+    """Tests for the CLI --check flag."""
 
     def test_check_flag_parsed(self):
-        """--check フラグがパースされること"""
+        """The --check flag is parsed."""
         from speedtest_z.cli import _build_parser
 
         parser = _build_parser()
@@ -160,7 +160,7 @@ class TestCliCheckFlag:
         assert args.check is True
 
     def test_check_default_false(self):
-        """デフォルトで check=False"""
+        """check defaults to False."""
         from speedtest_z.cli import _build_parser
 
         parser = _build_parser()
@@ -168,7 +168,7 @@ class TestCliCheckFlag:
         assert args.check is False
 
     def test_check_with_sites(self):
-        """--check cloudflare netflix でサイト指定可能"""
+        """Sites can be specified with --check cloudflare netflix."""
         from speedtest_z.cli import _build_parser
 
         parser = _build_parser()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,20 +1,20 @@
-"""__init__.py のテスト"""
+"""Tests for __init__.py."""
 
 import re
 from unittest.mock import patch
 
 
 class TestVersion:
-    """バージョン取得のテスト"""
+    """Tests for version retrieval."""
 
     def test_version_is_string(self):
-        """__version__ が文字列であること"""
+        """__version__ should be a string."""
         from speedtest_z import __version__
 
         assert isinstance(__version__, str)
 
     def test_version_not_empty(self):
-        """__version__ が空でないこと"""
+        """__version__ should not be empty."""
         from speedtest_z import __version__
 
         assert len(__version__) > 0

--- a/tests/test_otel.py
+++ b/tests/test_otel.py
@@ -1,4 +1,4 @@
-"""OpenTelemetry 統合のテスト"""
+"""Tests for the OpenTelemetry integration."""
 
 import configparser
 from unittest.mock import MagicMock, patch
@@ -15,15 +15,15 @@ try:
 except ImportError:
     _has_otel = False
 
-# --- OtelSender のユニットテスト ---
+# --- Unit tests for OtelSender ---
 
 
 @pytest.mark.skipif(not _has_otel, reason="opentelemetry not installed")
 class TestOtelSender:
-    """OtelSender のテスト"""
+    """Tests for OtelSender."""
 
     def _make_sender(self):
-        """モック化した OtelSender を作成"""
+        """Create a mocked OtelSender."""
         with (
             patch("speedtest_z.otel.OTLPMetricExporter") as mock_exporter_cls,
             patch("speedtest_z.otel.PeriodicExportingMetricReader"),
@@ -41,21 +41,21 @@ class TestOtelSender:
                 {"Api-Key": "test-key"},
                 "test-host",
             )
-            # モック参照を保持
+            # Keep references to the mocks
             sender._mock_exporter_cls = mock_exporter_cls
             sender._mock_provider = mock_provider
             sender._mock_meter = mock_meter
         return sender
 
     def test_init(self):
-        """初期化で属性が設定されること"""
+        """Attributes are set during initialization."""
         sender = self._make_sender()
         assert sender.provider is not None
         assert sender.meter is not None
         assert sender._gauges == {}
 
     def test_send_numeric_values(self):
-        """数値メトリクスが gauge に記録されること"""
+        """Numeric metrics are recorded on a gauge."""
         sender = self._make_sender()
         mock_gauge = MagicMock()
         sender._mock_meter.create_gauge.return_value = mock_gauge
@@ -66,37 +66,37 @@ class TestOtelSender:
         ]
         sender.send(data)
 
-        # gauge が作成されたことを確認
+        # Verify the gauges were created
         assert sender._mock_meter.create_gauge.call_count == 2
-        # set() が呼ばれたことを確認
+        # Verify set() was called
         assert mock_gauge.set.call_count == 2
         mock_gauge.set.assert_any_call(100.5, {"site": "cloudflare", "host": "test-host"})
         mock_gauge.set.assert_any_call(50.2, {"site": "cloudflare", "host": "test-host"})
-        # force_flush が呼ばれたことを確認
+        # Verify force_flush was called
         sender._mock_provider.force_flush.assert_called_once()
 
     def test_send_skips_non_numeric(self):
-        """数値でない値はスキップされること"""
+        """Non-numeric values are skipped."""
         sender = self._make_sender()
         data = [
             {"key": "netflix.server-locations", "value": "Tokyo, Osaka"},
             {"key": "boxtest.POP", "value": "NRT"},
         ]
         sender.send(data)
-        # gauge が作成されない
+        # No gauge is created
         sender._mock_meter.create_gauge.assert_not_called()
-        # force_flush は呼ばれる（空でも）
+        # force_flush is still called (even when empty)
         sender._mock_provider.force_flush.assert_called_once()
 
     def test_send_skips_invalid_key(self):
-        """ドットなしの key はスキップされること"""
+        """A key without a dot is skipped."""
         sender = self._make_sender()
         data = [{"key": "invalid_key", "value": "100.5"}]
         sender.send(data)
         sender._mock_meter.create_gauge.assert_not_called()
 
     def test_send_mixed_values(self):
-        """数値と非数値が混在する場合、数値のみ記録されること"""
+        """When numeric and non-numeric values are mixed, only the numeric ones are recorded."""
         sender = self._make_sender()
         mock_gauge = MagicMock()
         sender._mock_meter.create_gauge.return_value = mock_gauge
@@ -106,19 +106,19 @@ class TestOtelSender:
             {"key": "netflix.server-locations", "value": "Tokyo"},
         ]
         sender.send(data)
-        # 数値の1つだけ gauge が作成される
+        # A gauge is created only for the single numeric value
         sender._mock_meter.create_gauge.assert_called_once_with("speedtest_download")
         mock_gauge.set.assert_called_once_with(100.5, {"site": "cloudflare", "host": "test"})
 
     def test_send_empty_list(self):
-        """空リストでもエラーにならないこと"""
+        """An empty list does not error."""
         sender = self._make_sender()
         sender.send([])
         sender._mock_meter.create_gauge.assert_not_called()
         sender._mock_provider.force_flush.assert_called_once()
 
     def test_send_caches_gauge(self):
-        """同名メトリクスの gauge がキャッシュされること"""
+        """The gauge for an identically named metric is cached."""
         sender = self._make_sender()
         mock_gauge = MagicMock()
         sender._mock_meter.create_gauge.return_value = mock_gauge
@@ -128,12 +128,12 @@ class TestOtelSender:
             {"key": "netflix.download", "value": "80.0", "host": "h1"},
         ]
         sender.send(data)
-        # 同じ metric_name "speedtest_download" なので create_gauge は1回
+        # Same metric_name "speedtest_download", so create_gauge is called once
         sender._mock_meter.create_gauge.assert_called_once_with("speedtest_download")
         assert mock_gauge.set.call_count == 2
 
     def test_send_hyphen_to_underscore(self):
-        """メトリクス名のハイフンがアンダースコアに変換されること"""
+        """Hyphens in the metric name are converted to underscores."""
         sender = self._make_sender()
         mock_gauge = MagicMock()
         sender._mock_meter.create_gauge.return_value = mock_gauge
@@ -144,20 +144,20 @@ class TestOtelSender:
         mock_gauge.set.assert_called_once_with(3.0, {"site": "netflix", "host": "h1"})
 
     def test_shutdown(self):
-        """shutdown() で provider.shutdown() が呼ばれること"""
+        """provider.shutdown() is called by shutdown()."""
         sender = self._make_sender()
         sender.shutdown()
         sender._mock_provider.shutdown.assert_called_once()
 
 
-# --- ImportError 時のフォールバックテスト ---
+# --- Fallback tests for ImportError ---
 
 
 class TestOtelImportFallback:
-    """opentelemetry 未インストール時の graceful fallback テスト"""
+    """Graceful fallback tests for when opentelemetry is not installed."""
 
     def test_runner_otel_without_opentelemetry(self):
-        """opentelemetry なしで [otel] enable=true の場合、警告が出ること"""
+        """A warning is emitted when [otel] enable=true but opentelemetry is missing."""
         config = configparser.ConfigParser()
         config.read_dict(
             {
@@ -186,7 +186,7 @@ class TestOtelImportFallback:
             app.dryrun = True
             app.otel_sender = None
             app.zabbix_host = "test"
-            # [otel] セクションの読み込みをシミュレート
+            # Simulate loading the [otel] section
             if config.has_section("otel"):
                 otel_enable = config.getboolean("otel", "enable", fallback=False)
                 if otel_enable:
@@ -197,11 +197,11 @@ class TestOtelImportFallback:
             assert app.otel_sender is None
 
 
-# --- send_results() の統合テスト ---
+# --- Integration tests for send_results() ---
 
 
 def _make_sender(dryrun=True, zabbix_enable=False, grafana_sender=None, otel_sender=None):
-    """SenderManager インスタンスを直接作成"""
+    """Create a SenderManager instance directly."""
     with patch.object(SenderManager, "__init__", lambda self, *a, **kw: None):
         sender = SenderManager.__new__(SenderManager)
         sender.dry_run = dryrun
@@ -215,10 +215,10 @@ def _make_sender(dryrun=True, zabbix_enable=False, grafana_sender=None, otel_sen
 
 
 class TestSendResultsOtel:
-    """SenderManager.send() の OTel 送信テスト"""
+    """OTel send tests for SenderManager.send()."""
 
     def test_otel_sender_called(self):
-        """otel_sender が設定されていれば send() が呼ばれること"""
+        """send() is called when otel_sender is set."""
         mock_otel = MagicMock()
         sender = _make_sender(dryrun=False, otel_sender=mock_otel)
         data = [{"key": "cloudflare.download", "value": "100.5"}]
@@ -227,7 +227,7 @@ class TestSendResultsOtel:
             mock_otel.send.assert_called_once_with(data)
 
     def test_otel_sender_not_called_on_dryrun(self):
-        """dryrun=True では otel_sender.send() が呼ばれないこと"""
+        """otel_sender.send() is not called when dryrun=True."""
         mock_otel = MagicMock()
         sender = _make_sender(dryrun=True, otel_sender=mock_otel)
         data = [{"key": "cloudflare.download", "value": "100.5"}]
@@ -235,16 +235,16 @@ class TestSendResultsOtel:
         mock_otel.send.assert_not_called()
 
     def test_otel_error_handled(self):
-        """OTel 送信エラーでもクラッシュしないこと"""
+        """An OTel send error does not crash the run."""
         mock_otel = MagicMock()
         mock_otel.send.side_effect = Exception("Connection error")
         sender = _make_sender(dryrun=False, otel_sender=mock_otel)
         data = [{"key": "cloudflare.download", "value": "100.5"}]
         with patch("speedtest_z.sender.Sender"):
-            sender.send(data)  # 例外が伝播しない
+            sender.send(data)  # the exception does not propagate
 
     def test_all_three_backends(self):
-        """Zabbix, Grafana, OTel の3つ全てが呼ばれること"""
+        """All three of Zabbix, Grafana, and OTel are called."""
         mock_grafana = MagicMock()
         mock_otel = MagicMock()
         sender = _make_sender(
@@ -263,20 +263,20 @@ class TestSendResultsOtel:
             mock_otel.send.assert_called_once_with(data)
 
 
-# --- close() の OTel シャットダウンテスト ---
+# --- OTel shutdown tests for close() ---
 
 
 class TestCloseOtel:
-    """SenderManager.close() での OTel シャットダウンテスト"""
+    """OTel shutdown tests for SenderManager.close()."""
 
     def test_close_calls_otel_shutdown(self):
-        """close() で otel_sender.shutdown() が呼ばれること"""
+        """otel_sender.shutdown() is called by close()."""
         mock_otel = MagicMock()
         sender = _make_sender(otel_sender=mock_otel)
         sender.close()
         mock_otel.shutdown.assert_called_once()
 
     def test_close_without_otel(self):
-        """otel_sender=None でも close() がエラーにならないこと"""
+        """close() does not error even when otel_sender=None."""
         sender = _make_sender(otel_sender=None)
-        sender.close()  # エラーが出ないこと
+        sender.close()  # should not raise

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,4 +1,4 @@
-"""JSON/CSV 出力 (--output) のテスト"""
+"""Tests for JSON/CSV output (--output)."""
 
 import csv
 import io
@@ -8,17 +8,17 @@ from speedtest_z.output import OutputCollector
 
 
 class TestOutputCollector:
-    """OutputCollector のテスト"""
+    """Tests for OutputCollector."""
 
     def _sample_data(self):
-        """テスト用データ"""
+        """Test data."""
         return [
             {"host": "speedtest-agent", "key": "cloudflare.download", "value": "150.3"},
             {"host": "speedtest-agent", "key": "cloudflare.upload", "value": "45.7"},
         ]
 
     def test_add_records(self):
-        """add() でレコードが蓄積される"""
+        """Records accumulate via add()."""
         collector = OutputCollector("json")
         collector.add(self._sample_data())
         assert len(collector._records) == 2
@@ -26,22 +26,22 @@ class TestOutputCollector:
         assert collector._records[1]["value"] == "45.7"
 
     def test_add_includes_timestamp(self):
-        """add() で timestamp が追加される"""
+        """add() adds a timestamp."""
         collector = OutputCollector("json")
         collector.add(self._sample_data())
         assert "timestamp" in collector._records[0]
-        # ISO 8601 形式
+        # ISO 8601 format
         assert "T" in collector._records[0]["timestamp"]
 
     def test_multiple_add(self):
-        """複数回 add() でレコードが累積"""
+        """Records accumulate across multiple add() calls."""
         collector = OutputCollector("json")
         collector.add(self._sample_data())
         collector.add([{"host": "h", "key": "netflix.download", "value": "100"}])
         assert len(collector._records) == 3
 
     def test_flush_json(self, capsys):
-        """JSON 出力が正しくフォーマットされる"""
+        """JSON output is formatted correctly."""
         collector = OutputCollector("json")
         collector.add(self._sample_data())
         collector.flush()
@@ -52,7 +52,7 @@ class TestOutputCollector:
         assert data[0]["key"] == "cloudflare.download"
 
     def test_flush_csv(self, capsys):
-        """CSV 出力にヘッダーとデータが含まれる"""
+        """CSV output includes a header and data."""
         collector = OutputCollector("csv")
         collector.add(self._sample_data())
         collector.flush()
@@ -65,31 +65,31 @@ class TestOutputCollector:
         assert "timestamp" in rows[0]
 
     def test_flush_csv_empty(self, capsys):
-        """空のコレクターで CSV flush しても何も出力しない"""
+        """Flushing CSV on an empty collector outputs nothing."""
         collector = OutputCollector("csv")
         collector.flush()
         captured = capsys.readouterr()
         assert captured.out == ""
 
     def test_flush_json_empty(self, capsys):
-        """空のコレクターで JSON flush すると空配列"""
+        """Flushing JSON on an empty collector yields an empty array."""
         collector = OutputCollector("json")
         collector.flush()
         captured = capsys.readouterr()
         assert json.loads(captured.out) == []
 
     def test_host_fallback_empty(self):
-        """host キーがない場合は空文字"""
+        """An empty string is used when the host key is absent."""
         collector = OutputCollector("json")
         collector.add([{"key": "test.key", "value": "42"}])
         assert collector._records[0]["host"] == ""
 
 
 class TestCliOutputFlag:
-    """CLI --output フラグのテスト"""
+    """Tests for the CLI --output flag."""
 
     def test_output_default_zabbix(self):
-        """デフォルトは zabbix"""
+        """The default is zabbix."""
         from speedtest_z.cli import _build_parser
 
         parser = _build_parser()

--- a/tests/test_sites/test_cloudflare.py
+++ b/tests/test_sites/test_cloudflare.py
@@ -1,4 +1,4 @@
-"""cloudflare サイトランナーのテスト"""
+"""Tests for the cloudflare site runner."""
 
 from unittest.mock import MagicMock, patch
 
@@ -8,7 +8,7 @@ from speedtest_z.sites.cloudflare import _extract_by_label, run_cloudflare
 
 
 def _make_driver_with_label(label_text, parent_text):
-    """ラベル付きの DOM 要素をモックした WebDriver を返す"""
+    """Return a WebDriver mock with a labeled DOM element."""
     driver = MagicMock()
     label_el = MagicMock()
     parent_el = MagicMock()
@@ -19,70 +19,70 @@ def _make_driver_with_label(label_text, parent_text):
 
 
 class TestExtractByLabel:
-    """_extract_by_label() の抽出ロジックテスト"""
+    """Tests for the extraction logic of _extract_by_label()."""
 
     def test_extract_download_mbps(self):
-        """Download 150.3 Mbps を抽出"""
+        """Extract Download 150.3 Mbps."""
         driver = _make_driver_with_label("Download", "Download 150.3 Mbps")
         result = _extract_by_label(driver, "Download", "Mbps")
         assert result == "150.3"
 
     def test_extract_upload_mbps(self):
-        """Upload 45.7 Mbps を抽出"""
+        """Extract Upload 45.7 Mbps."""
         driver = _make_driver_with_label("Upload", "Upload 45.7 Mbps")
         result = _extract_by_label(driver, "Upload", "Mbps")
         assert result == "45.7"
 
     def test_extract_latency_ms(self):
-        """Latency 12.5 ms を抽出"""
+        """Extract Latency 12.5 ms."""
         driver = _make_driver_with_label("Latency", "Latency 12.5 ms")
         result = _extract_by_label(driver, "Latency", "ms")
         assert result == "12.5"
 
     def test_extract_jitter_microseconds(self):
-        """Jitter がマイクロ秒 (μs) の場合、ミリ秒に変換"""
+        """Convert Jitter in microseconds (us) to milliseconds."""
         driver = _make_driver_with_label("Jitter", "Jitter 500 \u03bcs")
         result = _extract_by_label(driver, "Jitter", r"ms|\u03bcs|us")
         assert result == "0.500"
 
     def test_extract_jitter_us_ascii(self):
-        """Jitter が ASCII us の場合もミリ秒に変換"""
+        """Convert Jitter to milliseconds when the unit is ASCII us."""
         driver = _make_driver_with_label("Jitter", "Jitter 200 us")
         result = _extract_by_label(driver, "Jitter", r"ms|\u03bcs|us")
         assert result == "0.200"
 
     def test_extract_jitter_ms(self):
-        """Jitter が ms の場合はそのまま"""
+        """Keep Jitter as-is when the unit is ms."""
         driver = _make_driver_with_label("Jitter", "Jitter 3.2 ms")
         result = _extract_by_label(driver, "Jitter", r"ms|\u03bcs|us")
         assert result == "3.2"
 
     def test_extract_integer_value(self):
-        """整数値（小数点なし）も抽出可能"""
+        """Integer values (no decimal point) can also be extracted."""
         driver = _make_driver_with_label("Download", "Download 200 Mbps")
         result = _extract_by_label(driver, "Download", "Mbps")
         assert result == "200.0"
 
     def test_extract_no_element_returns_empty(self):
-        """要素が見つからない場合は空文字を返す"""
+        """Return an empty string when the element is not found."""
         driver = MagicMock()
         driver.find_element.side_effect = NoSuchElementException()
         result = _extract_by_label(driver, "Download", "Mbps")
         assert result == ""
 
     def test_extract_no_match_returns_empty(self):
-        """パターンに合致しない場合は空文字を返す"""
+        """Return an empty string when the pattern does not match."""
         driver = _make_driver_with_label("Download", "Download N/A")
         result = _extract_by_label(driver, "Download", "Mbps")
         assert result == ""
 
     def test_extract_parent_no_digits_goes_grandparent(self):
-        """parent に数字がない場合は grandparent を探索"""
+        """Search the grandparent when the parent has no digits."""
         driver = MagicMock()
         label_el = MagicMock()
         parent_el = MagicMock()
         grandparent_el = MagicMock()
-        parent_el.text = "Download"  # 数字なし
+        parent_el.text = "Download"  # no digits
         grandparent_el.text = "Download 99.9 Mbps"
         parent_el.find_element.return_value = grandparent_el
         label_el.find_element.return_value = parent_el
@@ -92,17 +92,17 @@ class TestExtractByLabel:
 
 
 class TestRunCloudflare:
-    """run_cloudflare() の統合テスト"""
+    """Integration tests for run_cloudflare()."""
 
     def test_skip_when_should_run_false(self, mock_app):
-        """_should_run が False の場合スキップ"""
+        """Skip when _should_run returns False."""
         mock_app._should_run = MagicMock(return_value=False)
         mock_app.send_results = MagicMock()
         run_cloudflare(mock_app)
         mock_app.send_results.assert_not_called()
 
     def test_skip_when_load_fails(self, mock_app):
-        """ページ読み込み失敗時にスキップ"""
+        """Skip when the page fails to load."""
         mock_app._should_run = MagicMock(return_value=True)
         mock_app._load_with_retry = MagicMock(return_value=False)
         mock_app.send_results = MagicMock()
@@ -110,7 +110,7 @@ class TestRunCloudflare:
         mock_app.send_results.assert_not_called()
 
     def test_sends_data_on_success(self, mock_app):
-        """正常にデータ抽出・送信される"""
+        """Data is extracted and sent successfully."""
         mock_app._should_run = MagicMock(return_value=True)
         mock_app._load_with_retry = MagicMock(return_value=True)
         mock_app.send_results = MagicMock()

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -1,4 +1,4 @@
-"""take_snapshot のテスト"""
+"""Tests for take_snapshot."""
 
 from unittest.mock import MagicMock, patch
 
@@ -6,7 +6,7 @@ from speedtest_z.runner import SpeedtestZ
 
 
 def _make_app(snapshot_enable=False, snapshot_dir="/tmp/snapshots"):
-    """WebDriver を迂回して SpeedtestZ インスタンスを作成"""
+    """Create a SpeedtestZ instance, bypassing the WebDriver."""
     with patch.object(SpeedtestZ, "__init__", lambda self, *a, **kw: None):
         app = SpeedtestZ.__new__(SpeedtestZ)
         app.snapshot_enable = snapshot_enable
@@ -16,23 +16,23 @@ def _make_app(snapshot_enable=False, snapshot_dir="/tmp/snapshots"):
 
 
 class TestTakeSnapshot:
-    """take_snapshot() のテスト"""
+    """Tests for take_snapshot()."""
 
     def test_disabled_does_nothing(self):
-        """snapshot_enable=False の場合は何もしない"""
+        """Do nothing when snapshot_enable=False."""
         app = _make_app(snapshot_enable=False)
         app.take_snapshot("test")
         app.driver.save_screenshot.assert_not_called()
 
     def test_enabled_saves_screenshot(self):
-        """snapshot_enable=True の場合スクリーンショットを保存"""
+        """Save a screenshot when snapshot_enable=True."""
         app = _make_app(snapshot_enable=True, snapshot_dir="/tmp/snaps")
         app.take_snapshot("cloudflare")
         app.driver.save_screenshot.assert_called_once_with("/tmp/snaps/cloudflare.png")
 
     def test_exception_handled(self):
-        """save_screenshot が失敗してもエラーにならない"""
+        """No error is raised even when save_screenshot fails."""
         app = _make_app(snapshot_enable=True)
         app.driver.save_screenshot.side_effect = Exception("write error")
-        # 例外が伝播しないことを確認
+        # Verify the exception does not propagate
         app.take_snapshot("test")

--- a/tests/test_throttle.py
+++ b/tests/test_throttle.py
@@ -1,4 +1,4 @@
-"""スロットリング（_should_run）のテスト"""
+"""Tests for throttling (_should_run)."""
 
 from unittest.mock import patch
 
@@ -6,7 +6,7 @@ from speedtest_z.runner import SpeedtestZ
 
 
 def _make_app(mock_config, explicit_sites=False):
-    """WebDriver を迂回して SpeedtestZ インスタンスを作成"""
+    """Create a SpeedtestZ instance, bypassing the WebDriver."""
     with patch.object(SpeedtestZ, "__init__", lambda self, *a, **kw: None):
         app = SpeedtestZ.__new__(SpeedtestZ)
         app.config = mock_config
@@ -15,65 +15,65 @@ def _make_app(mock_config, explicit_sites=False):
 
 
 class TestShouldRun:
-    """_should_run() のテスト"""
+    """Tests for _should_run()."""
 
     def test_explicit_sites_always_true(self, mock_config):
-        """CLI でサイト明示指定時は常に True"""
+        """Always True when sites are explicitly specified on the CLI."""
         app = _make_app(mock_config, explicit_sites=True)
         assert app._should_run("cloudflare") is True
         assert app._should_run("mlab") is True
 
     def test_frequency_100(self, mock_config):
-        """frequency=100 は常に実行"""
+        """frequency=100 always runs."""
         app = _make_app(mock_config)
-        # cloudflare は config で 100
+        # cloudflare is 100 in the config
         assert app._should_run("cloudflare") is True
 
     def test_frequency_0(self, mock_config):
-        """frequency=0 は常にスキップ"""
+        """frequency=0 always skips."""
         mock_config.set("frequency", "cloudflare", "0")
         app = _make_app(mock_config)
         assert app._should_run("cloudflare") is False
 
     def test_frequency_50_run(self, mock_config):
-        """frequency=50 で乱数が範囲内なら実行"""
+        """frequency=50 runs when the random number is in range."""
         app = _make_app(mock_config)
-        # ookla は config で 50
+        # ookla is 50 in the config
         with patch("speedtest_z.runner.random.randint", return_value=30):
             assert app._should_run("ookla") is True
 
     def test_frequency_50_skip(self, mock_config):
-        """frequency=50 で乱数が範囲外ならスキップ"""
+        """frequency=50 skips when the random number is out of range."""
         app = _make_app(mock_config)
         with patch("speedtest_z.runner.random.randint", return_value=80):
             assert app._should_run("ookla") is False
 
     def test_frequency_boundary_run(self, mock_config):
-        """frequency=50 で乱数がちょうど50なら実行"""
+        """frequency=50 runs when the random number is exactly 50."""
         app = _make_app(mock_config)
         with patch("speedtest_z.runner.random.randint", return_value=50):
             assert app._should_run("ookla") is True
 
     def test_frequency_boundary_skip(self, mock_config):
-        """frequency=50 で乱数が51ならスキップ"""
+        """frequency=50 skips when the random number is 51."""
         app = _make_app(mock_config)
         with patch("speedtest_z.runner.random.randint", return_value=51):
             assert app._should_run("ookla") is False
 
     def test_frequency_fallback_default(self, mock_config):
-        """config に未定義のサイトはフォールバック 100（常に実行）"""
+        """Sites undefined in the config fall back to 100 (always run)."""
         app = _make_app(mock_config)
-        # config にないサイト名
+        # site name not in the config
         assert app._should_run("unknown_site") is True
 
     def test_frequency_negative(self, mock_config):
-        """frequency が負の値でもスキップ"""
+        """A negative frequency also skips."""
         mock_config.set("frequency", "cloudflare", "-10")
         app = _make_app(mock_config)
         assert app._should_run("cloudflare") is False
 
     def test_frequency_over_100(self, mock_config):
-        """frequency が 100 超でも常に実行"""
+        """A frequency over 100 still always runs."""
         mock_config.set("frequency", "cloudflare", "200")
         app = _make_app(mock_config)
         assert app._should_run("cloudflare") is True

--- a/tests/test_zabbix.py
+++ b/tests/test_zabbix.py
@@ -1,4 +1,4 @@
-"""Zabbix 送信ロジックのテスト"""
+"""Tests for the Zabbix send logic."""
 
 from unittest.mock import MagicMock, patch
 
@@ -7,7 +7,7 @@ from speedtest_z.sender import SenderManager
 
 
 def _make_app(dryrun=True, zabbix_enable=True):
-    """WebDriver を迂回して SpeedtestZ インスタンスを作成"""
+    """Create a SpeedtestZ instance, bypassing the WebDriver."""
     with patch.object(SpeedtestZ, "__init__", lambda self, *a, **kw: None):
         app = SpeedtestZ.__new__(SpeedtestZ)
         sender = MagicMock(spec=SenderManager)
@@ -30,7 +30,7 @@ def _make_app(dryrun=True, zabbix_enable=True):
 
 
 def _make_sender(dryrun=True, zabbix_enable=True):
-    """SenderManager インスタンスを直接作成"""
+    """Create a SenderManager instance directly."""
     with patch.object(SenderManager, "__init__", lambda self, *a, **kw: None):
         sender = SenderManager.__new__(SenderManager)
         sender.dry_run = dryrun
@@ -44,17 +44,17 @@ def _make_sender(dryrun=True, zabbix_enable=True):
 
 
 class TestSendResults:
-    """send_results() のテスト（SenderManager.send() を直接テスト）"""
+    """Tests for send_results() (directly testing SenderManager.send())."""
 
     def test_empty_list(self):
-        """空リストでは何もしない"""
+        """Does nothing for an empty list."""
         sender = _make_sender()
         with patch("speedtest_z.sender.Sender") as mock_sender:
             sender.send([])
             mock_sender.assert_not_called()
 
     def test_dryrun_no_send(self):
-        """dryrun=True では Sender.send_bulk() が呼ばれない"""
+        """Sender.send_bulk() is not called when dryrun=True."""
         sender = _make_sender(dryrun=True)
         data = [{"key": "speedtest.dl", "value": "100.5"}]
         with patch("speedtest_z.sender.Sender") as mock_sender:
@@ -62,7 +62,7 @@ class TestSendResults:
             mock_sender.assert_not_called()
 
     def test_send_called(self):
-        """dryrun=False では Sender が生成され send_bulk() が呼ばれる"""
+        """When dryrun=False, a Sender is created and send_bulk() is called."""
         sender = _make_sender(dryrun=False, zabbix_enable=True)
         data = [{"key": "speedtest.dl", "value": "100.5"}]
         with patch("speedtest_z.sender.Sender") as mock_sender_cls:
@@ -74,7 +74,7 @@ class TestSendResults:
             mock_instance.send_bulk.assert_called_once()
 
     def test_sender_data_construction(self):
-        """SenderData が正しく構築される"""
+        """SenderData is constructed correctly."""
         sender = _make_sender(dryrun=False, zabbix_enable=True)
         data = [
             {"key": "speedtest.dl", "value": "100.5"},
@@ -88,13 +88,13 @@ class TestSendResults:
             mock_sender_cls.return_value = mock_instance
             sender.send(data)
 
-            # デフォルトホスト名で SenderData が2回呼ばれる
+            # SenderData is called twice with the default host name
             assert mock_sd.call_count == 2
             mock_sd.assert_any_call("speedtest-agent", "speedtest.dl", "100.5")
             mock_sd.assert_any_call("speedtest-agent", "speedtest.ul", "50.2")
 
     def test_custom_host(self):
-        """データに host を含む場合はそちらを使う"""
+        """When the data includes a host, that one is used."""
         sender = _make_sender(dryrun=False, zabbix_enable=True)
         data = [{"host": "custom-host", "key": "speedtest.dl", "value": "99"}]
         with (
@@ -107,7 +107,7 @@ class TestSendResults:
             mock_sd.assert_called_once_with("custom-host", "speedtest.dl", "99")
 
     def test_send_error_handled(self):
-        """送信エラーでもクラッシュしない"""
+        """A send error does not crash the run."""
         sender = _make_sender(dryrun=False, zabbix_enable=True)
         data = [{"key": "speedtest.dl", "value": "100"}]
         with patch("speedtest_z.sender.Sender") as mock_sender_cls:
@@ -115,11 +115,11 @@ class TestSendResults:
             mock_instance.send_bulk.side_effect = Exception("Connection refused")
             mock_sender_cls.return_value = mock_instance
 
-            # 例外が伝播しないことを確認
+            # Verify the exception does not propagate
             sender.send(data)
 
     def test_delegation_from_app(self):
-        """SpeedtestZ.send_results() が SenderManager.send() に委譲すること"""
+        """SpeedtestZ.send_results() delegates to SenderManager.send()."""
         app = _make_app(dryrun=False, zabbix_enable=True)
         data = [{"key": "speedtest.dl", "value": "100.5"}]
         app.send_results(data)


### PR DESCRIPTION
## Summary

Migrate the remaining **Japanese code comments and docstrings to English** (CLAUDE.md public-repo policy) across `speedtest_z/`, `tests/`, and the deb/rpm maintainer scripts. **Comments and docstrings only** — no code, logic, identifiers, or formatting changed.

> Re-submission of #19 (which auto-closed when its stacked base branch was deleted on merge of #18). Rebased onto current `main`; content is identical to the reviewed #19, plus a `.coverage` cleanup (see below).

## Preserved (intentionally) — runtime Japanese strings

- `speedtest_z/i18n.py` — the `_MESSAGES` dict **Japanese values** (ja localization).
- `tests/test_cli.py` — assertions that verify Japanese localized output (e.g. `_msg("confirm_abort") == "中止しました。"`).

## Extra: artifact hygiene

The previous commit accidentally swept the local `.coverage` artifact into the diff (via `git add -A`). This commit excludes it and adds `.coverage` / `.coverage.*` / `htmlcov/` to `.gitignore` so it can't recur.

## Verification

- `ruff check` / `ruff format --check` / `mypy`: clean.
- **`pytest`: 312 passed, 9 skipped** — i18n tests and Japanese assertions still pass (no runtime string altered).
- No Japanese remains in any comment/docstring; the only Japanese left is the 18 expected runtime-string lines (11 `i18n.py` values + 7 `test_cli.py` assertions).
- `.coverage` is not tracked and is now gitignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)