### PR TITLE
ci: lint workflows with actionlint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,20 @@ permissions:
   contents: read
 
 jobs:
+  # Lint the GitHub Actions workflows themselves (incl. shellcheck on run blocks)
+  # so workflow mistakes are caught at PR time, not only when release.yml/deb.yml/
+  # rpm.yml run at release. Separate job so the test (3.x) check names stay stable.
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Lint workflows (actionlint)
+        shell: bash
+        run: |
+          bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/v1.7.12/scripts/download-actionlint.bash) 1.7.12
+          ./actionlint -color
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -67,8 +67,7 @@ jobs:
       - name: Rename .deb with codename suffix
         run: |
           for deb in ../speedtest-z_*.deb; do
-            newname=$(echo "$deb" | sed "s/\.deb$/~${{ matrix.codename }}.deb/")
-            mv "$deb" "$newname"
+            mv "$deb" "${deb%.deb}~${{ matrix.codename }}.deb"
           done
 
       # The GitHub Release already exists (this workflow is triggered by


### PR DESCRIPTION
## Summary

Adds **actionlint** to CI so GitHub Actions workflow mistakes (bad expressions, deprecated syntax) and **shellcheck issues in `run:` blocks** are caught at PR time — addressing the gap that `release.yml` / `deb.yml` / `rpm.yml` are otherwise only exercised at release time.

## Changes

- **ci.yml**: new `actionlint` job (pinned **v1.7.12** via the official download script). Separate top-level job — not folded into the `test` matrix — so the `test (3.x)` check names stay stable for branch protection (same approach jquants-mcp uses for its lint job). The runner's pre-installed shellcheck is used automatically for `run:` blocks.
- **deb.yml**: fix the one issue actionlint surfaced — the `.deb` rename used `echo | sed` (shellcheck SC2001); replaced with bash parameter expansion (`mv "$deb" "${deb%.deb}~<codename>.deb"`).

## Verification

- `actionlint 1.7.12` run locally over all workflows: **zero findings** (so the new job is green).
- All workflow YAML parses.
- No app code changed.

## Note

Pinned to `v1.7.12` (script fetched from the matching tag, binary version pinned) for reproducibility. Bump as needed when newer actionlint releases land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)