### PR TITLE
feat: stamp speedtest-z version onto the Zabbix host as a tag

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -133,7 +133,7 @@ pip install speedtest-z[zabbix-api]
 uv tool install "speedtest-z[zabbix-api]"
 ```
 
-[zapi-mcp](https://github.com/shigechika/zapi-mcp) がインストールされ、トラッパー送信に加えて、実行中の speedtest-z バージョンを Zabbix API 経由で host tag（`speedtest-z=<version>`）として付与できます。`[zabbix]` セクションの `api_url` / `api_user` / `api_password` を設定すると有効になります。
+[zapi-mcp](https://github.com/shigechika/zapi-mcp) がインストールされ、トラッパー送信に加えて、実行中の speedtest-z バージョンを Zabbix API 経由で host tag（`speedtest-z=<version>`）として付与できます。`[zabbix]` セクションの `api_url` / `api_user` / `api_password` を設定すると有効になります。`api_url` は https を推奨し、`config.ini` は所有者のみ読めるよう権限を制限してください（パスワードは平文で保存されます）。Zabbix API ユーザーは最小権限（`host.update` のみ）を推奨します。
 
 ### タブ補完（任意）
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -124,6 +124,17 @@ uv tool install "speedtest-z[otel]"
 
 OpenTelemetry SDK と OTLP HTTP エクスポーターがインストールされます。
 
+### Zabbix ホストバージョンタグ（オプション）
+
+```bash
+pip install speedtest-z[zabbix-api]
+
+# uv を使う場合
+uv tool install "speedtest-z[zabbix-api]"
+```
+
+[zapi-mcp](https://github.com/shigechika/zapi-mcp) がインストールされ、トラッパー送信に加えて、実行中の speedtest-z バージョンを Zabbix API 経由で host tag（`speedtest-z=<version>`）として付与できます。`[zabbix]` セクションの `api_url` / `api_user` / `api_password` を設定すると有効になります。
+
 ### タブ補完（任意）
 
 ```bash
@@ -165,6 +176,11 @@ enable = false           # true にすると Zabbix へ送信する
 server = 127.0.0.1       # 送信先 Zabbix Server
 port = 10051             # Zabbix トラッパーポート
 host = speedtest-agent   # Zabbix ホスト名
+# 任意: バージョンを host tag（speedtest-z=<version>）として Zabbix API 経由で付与。
+# speedtest-z[zabbix-api] が必要。api_url/api_user/api_password の3つすべて設定すると有効。
+# api_url = https://zabbix.example.com/api_jsonrpc.php
+# api_user = api-user
+# api_password = api-pass
 ```
 
 #### `[grafana]` セクション（オプション）

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ pip install speedtest-z[zabbix-api]
 uv tool install "speedtest-z[zabbix-api]"
 ```
 
-This installs [zapi-mcp](https://github.com/shigechika/zapi-mcp) so speedtest-z can stamp its running version onto the Zabbix host as a tag (`speedtest-z=<version>`) via the Zabbix JSON-RPC API, alongside the trapper send path. Set `api_url` / `api_user` / `api_password` under `[zabbix]` to enable it.
+This installs [zapi-mcp](https://github.com/shigechika/zapi-mcp) so speedtest-z can stamp its running version onto the Zabbix host as a tag (`speedtest-z=<version>`) via the Zabbix JSON-RPC API, alongside the trapper send path. Set `api_url` / `api_user` / `api_password` under `[zabbix]` to enable it. Use an `https` `api_url`, keep `config.ini` readable only by its owner (the password is stored in plaintext), and prefer a least-privilege Zabbix API user (`host.update` only).
 
 ### Tab Completion (optional)
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,17 @@ uv tool install "speedtest-z[otel]"
 
 This installs the OpenTelemetry SDK and OTLP HTTP exporter for sending metrics via OTLP.
 
+### Zabbix Host Version Tag (optional)
+
+```bash
+pip install speedtest-z[zabbix-api]
+
+# or using uv
+uv tool install "speedtest-z[zabbix-api]"
+```
+
+This installs [zapi-mcp](https://github.com/shigechika/zapi-mcp) so speedtest-z can stamp its running version onto the Zabbix host as a tag (`speedtest-z=<version>`) via the Zabbix JSON-RPC API, alongside the trapper send path. Set `api_url` / `api_user` / `api_password` under `[zabbix]` to enable it.
+
 ### Tab Completion (optional)
 
 ```bash
@@ -175,6 +186,11 @@ enable = false           # true = send results to Zabbix
 server = 127.0.0.1
 port = 10051
 host = speedtest-agent   # Zabbix host name for trapper items
+# Optional: stamp the version as a host tag (speedtest-z=<version>) via the
+# Zabbix API. Requires speedtest-z[zabbix-api]; all three must be set.
+# api_url = https://zabbix.example.com/api_jsonrpc.php
+# api_user = api-user
+# api_password = api-pass
 
 [snapshot]
 # Screenshot capture settings

--- a/config.ini-sample
+++ b/config.ini-sample
@@ -18,6 +18,8 @@ host = speedtest-agent
 # Optional: stamp the running version onto the host as a tag (speedtest-z=<version>)
 # via the Zabbix JSON-RPC API. Separate from the trapper send above; requires the
 # zapi-mcp package. All three must be set to enable it.
+# NOTE: api_password is stored in plaintext. Restrict this file (e.g. chmod 600)
+# and use a least-privilege Zabbix API user (host.update only); prefer https.
 # api_url = https://zabbix.example.com/api_jsonrpc.php
 # api_user = api-user
 # api_password = api-pass

--- a/config.ini-sample
+++ b/config.ini-sample
@@ -15,6 +15,12 @@ enable = false
 server = 127.0.0.1
 port = 10051
 host = speedtest-agent
+# Optional: stamp the running version onto the host as a tag (speedtest-z=<version>)
+# via the Zabbix JSON-RPC API. Separate from the trapper send above; requires the
+# zapi-mcp package. All three must be set to enable it.
+# api_url = https://zabbix.example.com/api_jsonrpc.php
+# api_user = api-user
+# api_password = api-pass
 
 [snapshot]
 # Screenshot settings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ test = ["pytest", "pytest-cov"]
 completion = ["argcomplete"]
 grafana = ["cramjam"]
 otel = ["opentelemetry-api", "opentelemetry-sdk", "opentelemetry-exporter-otlp-proto-http"]
+zabbix-api = ["zapi-mcp>=0.3"]
 
 [project.urls]
 Homepage = "https://github.com/shigechika/speedtest-z"

--- a/speedtest_z/cli.py
+++ b/speedtest_z/cli.py
@@ -224,6 +224,9 @@ def main() -> None:
                 runner(app)
             else:
                 logger.warning(f"Unknown site: {site}")
+        # Stamp the running version onto the Zabbix host (no-op in dry-run,
+        # when the API is unconfigured, or for json/csv output).
+        app.stamp_version()
     except KeyboardInterrupt:
         logger.info("Interrupted by user")
     except Exception:

--- a/speedtest_z/runner.py
+++ b/speedtest_z/runner.py
@@ -214,6 +214,18 @@ class SpeedtestZ:
         """
         self.sender.send(data_list)
 
+    def stamp_version(self) -> None:
+        """Stamp the running version onto the Zabbix host as a tag.
+
+        Delegates to SenderManager.set_version_tag() when available; this is a
+        no-op for OutputCollector (json/csv mode), which has no such method.
+        """
+        stamp = getattr(self.sender, "set_version_tag", None)
+        if callable(stamp):
+            from speedtest_z import __version__
+
+            stamp(__version__)
+
     def _get_window_position(self) -> tuple[int, int]:
         """Calculate top-right window position based on OS."""
         if platform.system() == "Linux":

--- a/speedtest_z/sender.py
+++ b/speedtest_z/sender.py
@@ -165,9 +165,22 @@ class SenderManager:
         """
         if self.dry_run or not self.zabbix_enable:
             return
-        if not (self.zabbix_api_url and self.zabbix_api_user and self.zabbix_api_password):
-            logger.debug("[zabbix] API not configured; skipping version host tag")
+        api_fields = (self.zabbix_api_url, self.zabbix_api_user, self.zabbix_api_password)
+        if not all(api_fields):
+            if any(api_fields):
+                # Partial config is almost certainly a mistake (e.g. password
+                # left blank); surface it rather than skipping silently.
+                logger.warning(
+                    "[zabbix] API partially configured; set api_url, api_user and "
+                    "api_password to set the version host tag"
+                )
+            else:
+                logger.debug("[zabbix] API not configured; skipping version host tag")
             return
+        if _is_plaintext_remote(self.zabbix_api_url):
+            logger.warning(
+                "[zabbix] api_url is not https; the API password would be sent over plaintext"
+            )
         try:
             from zapi_mcp.client import ZapiClient
         except ImportError:

--- a/speedtest_z/sender.py
+++ b/speedtest_z/sender.py
@@ -44,6 +44,11 @@ class SenderManager:
         self.zabbix_server = config.get("zabbix", "server", fallback="127.0.0.1")
         self.zabbix_port = config.getint("zabbix", "port", fallback=10051)
         self.zabbix_host = host
+        # Optional Zabbix JSON-RPC API (for host tags); separate from the
+        # trapper send path above. All three must be set to enable it.
+        self.zabbix_api_url = config.get("zabbix", "api_url", fallback="")
+        self.zabbix_api_user = config.get("zabbix", "api_user", fallback="")
+        self.zabbix_api_password = config.get("zabbix", "api_password", fallback="")
 
         # Grafana
         self.grafana_sender = None
@@ -148,6 +153,37 @@ class SenderManager:
                 self.otel_sender.send(data_list)
             except Exception:
                 logger.exception("Failed to send to OTel")
+
+    def set_version_tag(self, version: str) -> None:
+        """Stamp the running speedtest-z version onto the Zabbix host as a tag.
+
+        Sets the host tag ``speedtest-z=<version>`` via the Zabbix JSON-RPC API
+        (separate from the trapper send path). No-op in dry-run, when Zabbix is
+        disabled, or when the API is not configured. Requires the optional
+        ``zapi-mcp`` package; a missing install or an API failure is logged,
+        not fatal.
+        """
+        if self.dry_run or not self.zabbix_enable:
+            return
+        if not (self.zabbix_api_url and self.zabbix_api_user and self.zabbix_api_password):
+            logger.debug("[zabbix] API not configured; skipping version host tag")
+            return
+        try:
+            from zapi_mcp.client import ZapiClient
+        except ImportError:
+            logger.warning(
+                "zapi-mcp not installed; cannot set the version host tag. "
+                "Install zapi-mcp to enable it."
+            )
+            return
+        try:
+            with ZapiClient(
+                self.zabbix_api_url, self.zabbix_api_user, self.zabbix_api_password
+            ) as client:
+                client.set_host_tag(self.zabbix_host, "speedtest-z", version)
+            logger.info(f"Zabbix host tag set: speedtest-z={version} on {self.zabbix_host}")
+        except Exception:
+            logger.exception("Failed to set the Zabbix version host tag")
 
     def close(self) -> None:
         """Shut down backends that need cleanup."""

--- a/tests/test_zabbix.py
+++ b/tests/test_zabbix.py
@@ -40,6 +40,9 @@ def _make_sender(dryrun=True, zabbix_enable=True):
         sender.zabbix_host = "speedtest-agent"
         sender.grafana_sender = None
         sender.otel_sender = None
+        sender.zabbix_api_url = ""
+        sender.zabbix_api_user = ""
+        sender.zabbix_api_password = ""
     return sender
 
 
@@ -124,3 +127,70 @@ class TestSendResults:
         data = [{"key": "speedtest.dl", "value": "100.5"}]
         app.send_results(data)
         app.sender.send.assert_called_once_with(data)
+
+
+class TestSetVersionTag:
+    """Tests for SenderManager.set_version_tag()."""
+
+    def _api_sender(self, dryrun=False, zabbix_enable=True):
+        """A sender with the Zabbix API fully configured."""
+        sender = _make_sender(dryrun=dryrun, zabbix_enable=zabbix_enable)
+        sender.zabbix_api_url = "https://z.example.com/api_jsonrpc.php"
+        sender.zabbix_api_user = "api-user"
+        sender.zabbix_api_password = "api-pass"
+        return sender
+
+    def _inject_zapi(self, monkeypatch):
+        """Inject a fake zapi_mcp.client.ZapiClient; return the class mock."""
+        import sys
+        import types
+
+        cls = MagicMock()
+        mod = types.ModuleType("zapi_mcp.client")
+        mod.ZapiClient = cls
+        monkeypatch.setitem(sys.modules, "zapi_mcp", types.ModuleType("zapi_mcp"))
+        monkeypatch.setitem(sys.modules, "zapi_mcp.client", mod)
+        return cls
+
+    def test_dryrun_skips(self, monkeypatch):
+        """No API call in dry-run, even when fully configured."""
+        cls = self._inject_zapi(monkeypatch)
+        self._api_sender(dryrun=True, zabbix_enable=True).set_version_tag("0.8.5")
+        cls.assert_not_called()
+
+    def test_disabled_skips(self, monkeypatch):
+        """No API call when Zabbix is disabled."""
+        cls = self._inject_zapi(monkeypatch)
+        self._api_sender(dryrun=False, zabbix_enable=False).set_version_tag("0.8.5")
+        cls.assert_not_called()
+
+    def test_unconfigured_skips(self, monkeypatch):
+        """No API call when the API credentials are absent."""
+        cls = self._inject_zapi(monkeypatch)
+        # _make_sender leaves the api_* fields empty.
+        _make_sender(dryrun=False, zabbix_enable=True).set_version_tag("0.8.5")
+        cls.assert_not_called()
+
+    def test_sets_host_tag(self, monkeypatch):
+        """The version is upserted as a host tag via ZapiClient."""
+        cls = self._inject_zapi(monkeypatch)
+        self._api_sender().set_version_tag("0.8.5")
+        cls.assert_called_once_with(
+            "https://z.example.com/api_jsonrpc.php", "api-user", "api-pass"
+        )
+        client = cls.return_value.__enter__.return_value
+        client.set_host_tag.assert_called_once_with("speedtest-agent", "speedtest-z", "0.8.5")
+
+    def test_missing_zapi_is_not_fatal(self, monkeypatch):
+        """A missing zapi-mcp install is logged, not raised."""
+        import sys
+
+        monkeypatch.setitem(sys.modules, "zapi_mcp", None)
+        monkeypatch.setitem(sys.modules, "zapi_mcp.client", None)
+        self._api_sender().set_version_tag("0.8.5")  # must not raise
+
+    def test_api_error_is_not_fatal(self, monkeypatch):
+        """An API/connection error is logged, not raised."""
+        cls = self._inject_zapi(monkeypatch)
+        cls.return_value.__enter__.side_effect = Exception("connection refused")
+        self._api_sender().set_version_tag("0.8.5")  # must not raise

--- a/tests/test_zabbix.py
+++ b/tests/test_zabbix.py
@@ -194,3 +194,43 @@ class TestSetVersionTag:
         cls = self._inject_zapi(monkeypatch)
         cls.return_value.__enter__.side_effect = Exception("connection refused")
         self._api_sender().set_version_tag("0.8.5")  # must not raise
+
+    def test_plaintext_api_url_warns(self, monkeypatch, caplog):
+        """A non-https api_url warns about plaintext but still proceeds."""
+        cls = self._inject_zapi(monkeypatch)
+        sender = self._api_sender()
+        sender.zabbix_api_url = "http://z.example.com/api_jsonrpc.php"
+        with caplog.at_level("WARNING", logger="speedtest-z"):
+            sender.set_version_tag("0.8.5")
+        cls.assert_called_once()  # still attempts the call
+        assert any("plaintext" in r.getMessage() for r in caplog.records)
+
+    def test_partial_config_warns_and_skips(self, monkeypatch, caplog):
+        """Partial API config (one field missing) warns and makes no API call."""
+        cls = self._inject_zapi(monkeypatch)
+        sender = _make_sender(dryrun=False, zabbix_enable=True)
+        sender.zabbix_api_url = "https://z.example.com/api_jsonrpc.php"
+        sender.zabbix_api_user = "api-user"
+        # api_password left empty -> partial config
+        with caplog.at_level("WARNING", logger="speedtest-z"):
+            sender.set_version_tag("0.8.5")
+        cls.assert_not_called()
+        assert any("partially configured" in r.getMessage() for r in caplog.records)
+
+
+def test_stamp_version_delegates_to_sender():
+    """SpeedtestZ.stamp_version() forwards __version__ to set_version_tag."""
+    from speedtest_z import __version__
+
+    app = _make_app(dryrun=False, zabbix_enable=True)
+    app.stamp_version()
+    app.sender.set_version_tag.assert_called_once_with(__version__)
+
+
+def test_stamp_version_noop_for_output_collector():
+    """stamp_version() is a no-op when the sender lacks set_version_tag (json/csv)."""
+    from speedtest_z.output import OutputCollector
+
+    app = _make_app()
+    app.sender = OutputCollector("json")
+    app.stamp_version()  # must not raise


### PR DESCRIPTION
## What

After all sites finish, speedtest-z sets the host tag **`speedtest-z=<version>`** on the configured Zabbix host via the Zabbix JSON-RPC API — alongside the existing trapper send path. This mirrors the `update_hostid(..., tag_name, tag_value)` pattern used by pyez-dhcp-status-z / srx-nat-usage.

Existing host tags are **preserved** (upsert by name via `zapi-mcp`'s `set_host_tag`), so a manually-set tag like `location` is not clobbered.

## Behavior

Enabled when `[zabbix] enable=true` **and** `api_url` / `api_user` / `api_password` are all set.

No-op when:
- `--dry-run`
- Zabbix disabled
- API unconfigured
- `--output json|csv` (OutputCollector has no `set_version_tag`)

A missing `zapi-mcp` install or an API/connection error is **logged, not fatal** — the measurement run never breaks (same robustness as grafana/otel).

## Changes

| File | Change |
|---|---|
| `sender.py` | read `api_url`/`api_user`/`api_password`; add `set_version_tag()` |
| `runner.py` | `stamp_version()` (no-op for OutputCollector) |
| `cli.py` | call `app.stamp_version()` after sites complete |
| `config.ini-sample`, `README*.md` | document `[zabbix]` api_* + `[zabbix-api]` extra |
| `tests/test_zabbix.py` | 6 tests for `set_version_tag` |

318 passed / 9 skipped; `ruff check` / `ruff format` clean.

## ⚠️ Merge order

Depends on **zapi-mcp** exposing `ZapiClient.set_host_tag` (https://github.com/shigechika/zapi-mcp/pull/5) and being **published to PyPI as 0.3+**. The `zabbix-api = ["zapi-mcp>=0.3"]` extra resolves only after that. Merge this **after** zapi-mcp 0.3.0 is on PyPI. The code itself is gated by a try-import, so the rest of speedtest-z is unaffected meanwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)