### PR TITLE
feat: depend on zapi-lib for the host-tag feature (+ deb/rpm extras)

### DIFF
--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -55,7 +55,7 @@ jobs:
           /opt/venvs/speedtest-z/bin/pip install --upgrade pip setuptools
           # Version is static in pyproject.toml (managed by release-please),
           # so no SETUPTOOLS_SCM_PRETEND_VERSION is needed.
-          /opt/venvs/speedtest-z/bin/pip install ".[grafana,otel]"
+          /opt/venvs/speedtest-z/bin/pip install ".[grafana,otel,zabbix-api]"
           /opt/venvs/speedtest-z/bin/speedtest-z --version
 
       - name: Prepare staging directory

--- a/README.ja.md
+++ b/README.ja.md
@@ -133,7 +133,7 @@ pip install speedtest-z[zabbix-api]
 uv tool install "speedtest-z[zabbix-api]"
 ```
 
-[zapi-mcp](https://github.com/shigechika/zapi-mcp) がインストールされ、トラッパー送信に加えて、実行中の speedtest-z バージョンを Zabbix API 経由で host tag（`speedtest-z=<version>`）として付与できます。`[zabbix]` セクションの `api_url` / `api_user` / `api_password` を設定すると有効になります。`api_url` は https を推奨し、`config.ini` は所有者のみ読めるよう権限を制限してください（パスワードは平文で保存されます）。Zabbix API ユーザーは最小権限（`host.update` のみ）を推奨します。
+[zapi-lib](https://github.com/shigechika/zapi-lib) がインストールされ、トラッパー送信に加えて、実行中の speedtest-z バージョンを Zabbix API 経由で host tag（`speedtest-z=<version>`）として付与できます。`[zabbix]` セクションの `api_url` / `api_user` / `api_password` を設定すると有効になります。`api_url` は https を推奨し、`config.ini` は所有者のみ読めるよう権限を制限してください（パスワードは平文で保存されます）。Zabbix API ユーザーは最小権限（`host.update` のみ）を推奨します。
 
 ### タブ補完（任意）
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ pip install speedtest-z[zabbix-api]
 uv tool install "speedtest-z[zabbix-api]"
 ```
 
-This installs [zapi-mcp](https://github.com/shigechika/zapi-mcp) so speedtest-z can stamp its running version onto the Zabbix host as a tag (`speedtest-z=<version>`) via the Zabbix JSON-RPC API, alongside the trapper send path. Set `api_url` / `api_user` / `api_password` under `[zabbix]` to enable it. Use an `https` `api_url`, keep `config.ini` readable only by its owner (the password is stored in plaintext), and prefer a least-privilege Zabbix API user (`host.update` only).
+This installs [zapi-lib](https://github.com/shigechika/zapi-lib) so speedtest-z can stamp its running version onto the Zabbix host as a tag (`speedtest-z=<version>`) via the Zabbix JSON-RPC API, alongside the trapper send path. Set `api_url` / `api_user` / `api_password` under `[zabbix]` to enable it. Use an `https` `api_url`, keep `config.ini` readable only by its owner (the password is stored in plaintext), and prefer a least-privilege Zabbix API user (`host.update` only).
 
 ### Tab Completion (optional)
 

--- a/config.ini-sample
+++ b/config.ini-sample
@@ -17,7 +17,7 @@ port = 10051
 host = speedtest-agent
 # Optional: stamp the running version onto the host as a tag (speedtest-z=<version>)
 # via the Zabbix JSON-RPC API. Separate from the trapper send above; requires the
-# zapi-mcp package. All three must be set to enable it.
+# zapi-lib package. All three must be set to enable it.
 # NOTE: api_password is stored in plaintext. Restrict this file (e.g. chmod 600)
 # and use a least-privilege Zabbix API user (host.update only); prefer https.
 # api_url = https://zabbix.example.com/api_jsonrpc.php

--- a/debian/rules
+++ b/debian/rules
@@ -8,7 +8,7 @@ export SETUPTOOLS_SCM_PRETEND_VERSION=$(shell dpkg-parsechangelog -S Version | s
 override_dh_virtualenv:
 	dh_virtualenv --python /usr/bin/python3 \
 		--install-suffix speedtest-z \
-		--extras grafana,otel \
+		--extras grafana,otel,zabbix-api \
 		--preinstall "setuptools>=68.0" \
 		--preinstall "setuptools-scm>=8" \
 		--preinstall "pip>=23.0" --pip-tool pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ test = ["pytest", "pytest-cov"]
 completion = ["argcomplete"]
 grafana = ["cramjam"]
 otel = ["opentelemetry-api", "opentelemetry-sdk", "opentelemetry-exporter-otlp-proto-http"]
-zabbix-api = ["zapi-mcp>=0.3"]
+zabbix-api = ["zapi-lib>=0.1,<1"]
 
 [project.urls]
 Homepage = "https://github.com/shigechika/speedtest-z"

--- a/speedtest_z/sender.py
+++ b/speedtest_z/sender.py
@@ -160,7 +160,7 @@ class SenderManager:
         Sets the host tag ``speedtest-z=<version>`` via the Zabbix JSON-RPC API
         (separate from the trapper send path). No-op in dry-run, when Zabbix is
         disabled, or when the API is not configured. Requires the optional
-        ``zapi-mcp`` package; a missing install or an API failure is logged,
+        ``zapi-lib`` package; a missing install or an API failure is logged,
         not fatal.
         """
         if self.dry_run or not self.zabbix_enable:
@@ -182,11 +182,11 @@ class SenderManager:
                 "[zabbix] api_url is not https; the API password would be sent over plaintext"
             )
         try:
-            from zapi_mcp.client import ZapiClient
+            from zapi_lib import ZapiClient
         except ImportError:
             logger.warning(
-                "zapi-mcp not installed; cannot set the version host tag. "
-                "Install zapi-mcp to enable it."
+                "zapi-lib not installed; cannot set the version host tag. "
+                "Install speedtest-z[zabbix-api] to enable it."
             )
             return
         try:

--- a/tests/test_zabbix.py
+++ b/tests/test_zabbix.py
@@ -141,15 +141,14 @@ class TestSetVersionTag:
         return sender
 
     def _inject_zapi(self, monkeypatch):
-        """Inject a fake zapi_mcp.client.ZapiClient; return the class mock."""
+        """Inject a fake zapi_lib.ZapiClient; return the class mock."""
         import sys
         import types
 
         cls = MagicMock()
-        mod = types.ModuleType("zapi_mcp.client")
+        mod = types.ModuleType("zapi_lib")
         mod.ZapiClient = cls
-        monkeypatch.setitem(sys.modules, "zapi_mcp", types.ModuleType("zapi_mcp"))
-        monkeypatch.setitem(sys.modules, "zapi_mcp.client", mod)
+        monkeypatch.setitem(sys.modules, "zapi_lib", mod)
         return cls
 
     def test_dryrun_skips(self, monkeypatch):
@@ -182,11 +181,10 @@ class TestSetVersionTag:
         client.set_host_tag.assert_called_once_with("speedtest-agent", "speedtest-z", "0.8.5")
 
     def test_missing_zapi_is_not_fatal(self, monkeypatch):
-        """A missing zapi-mcp install is logged, not raised."""
+        """A missing zapi-lib install is logged, not raised."""
         import sys
 
-        monkeypatch.setitem(sys.modules, "zapi_mcp", None)
-        monkeypatch.setitem(sys.modules, "zapi_mcp.client", None)
+        monkeypatch.setitem(sys.modules, "zapi_lib", None)
         self._api_sender().set_version_tag("0.8.5")  # must not raise
 
     def test_api_error_is_not_fatal(self, monkeypatch):


### PR DESCRIPTION
## What
- Switch `[zabbix-api]` extra from `zapi-mcp` to the new **zapi-lib** (httpx-only): `pip install speedtest-z[zabbix-api]` no longer drags in the MCP server stack (mcp / starlette / uvicorn / pydantic, ~18 pkgs).
- `sender.py` imports `ZapiClient` from `zapi_lib`.
- **A-1**: add `zabbix-api` to deb (`debian/rules`) and rpm (`rpm.yml`) extras.

## Why
The v0.9.0 host-tag feature was a **silent no-op on packaged installs** — deb/rpm shipped `grafana,otel` only, so `zapi-mcp`/`zapi-lib` was never present and `set_version_tag` hit the ImportError branch. vlan403 (.deb) is the production deploy, so the feature was dead exactly where it mattered. zapi-lib also keeps the venv/CVE surface small.

## Changes
- `pyproject.toml`: `zabbix-api = ["zapi-lib>=0.1,<1"]`
- `speedtest_z/sender.py`: import + warning text → zapi-lib
- `debian/rules` / `.github/workflows/rpm.yml`: extras += zabbix-api
- `tests/test_zabbix.py`: mock module name → zapi_lib
- `config.ini-sample` / README (en/ja): zapi-mcp → zapi-lib

322 passed / 9 skipped; ruff clean.

## Note
Depends on **zapi-lib** being on PyPI (published as 0.2.0). Merge order: zapi-lib ✅ → zapi-mcp 0.5.0 ✅ → this. Verify post-merge that `speedtest-z[zabbix-api]` resolves without mcp/uvicorn/starlette.

🤖 Generated with [Claude Code](https://claude.com/claude-code)