### PR TITLE
chore: drop the <1 cap on the zapi-lib optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ test = ["pytest", "pytest-cov"]
 completion = ["argcomplete"]
 grafana = ["cramjam"]
 otel = ["opentelemetry-api", "opentelemetry-sdk", "opentelemetry-exporter-otlp-proto-http"]
-zabbix-api = ["zapi-lib>=0.1,<1"]
+zabbix-api = ["zapi-lib>=0.1"]
 
 [project.urls]
 Homepage = "https://github.com/shigechika/speedtest-z"


### PR DESCRIPTION
## Summary

Relax the `zabbix-api` extra from `zapi-lib>=0.1,<1` to **`zapi-lib>=0.1`**.

`zapi-lib` is a first-party, self-maintained library (same author), so an upper
`<1` cap adds no real safety — a breaking `1.0` would be released knowingly and
the pin bumped deliberately at that point. Dropping the cap avoids cargo-culted
version noise and keeps `pip install speedtest-z[zabbix-api]` resolving to the
latest compatible `zapi-lib`.

No functional change; metadata only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)