### PR TITLE
chore: require zapi-lib>=0.2 for the zabbix-api extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ test = ["pytest", "pytest-cov"]
 completion = ["argcomplete"]
 grafana = ["cramjam"]
 otel = ["opentelemetry-api", "opentelemetry-sdk", "opentelemetry-exporter-otlp-proto-http"]
-zabbix-api = ["zapi-lib>=0.1"]
+zabbix-api = ["zapi-lib>=0.2"]
 
 [project.urls]
 Homepage = "https://github.com/shigechika/speedtest-z"


### PR DESCRIPTION
Tighten the `zabbix-api` optional-dependency floor from `>=0.1` to `>=0.2`.

- zapi-lib has no `0.1.0` on PyPI (only `0.2.0`/`0.3.0`).
- The host-tag feature uses `ZapiClient.set_host_tag`, which first ships in `0.2.0`.

So `>=0.2` matches what is actually required; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)