### PR TITLE
chore: add Dependabot version-update config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` to enable Dependabot version-update PRs for this repo's Python/pip dependencies and GitHub Actions workflows (weekly checks).
- Mirrors the existing, working Dependabot config used in shigechika/jquants-mcp and shigechika/github-insights.
- Dependabot *security alerts* were already enabled separately via the repo settings API; this PR only adds the version-update config.

## Test plan
- [x] Validated the YAML parses (`yaml.safe_load`)
- [ ] Confirm Dependabot picks up the config and opens PRs on the next scheduled run