### PR TITLE
docs: add MkDocs Material site (en/ja) with GitHub Pages deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,68 @@
+name: Docs
+
+# Build the MkDocs site on every docs PR (--strict, so broken links/config
+# fail the check) and deploy it to GitHub Pages on push to main. Pages is
+# configured with Source: "GitHub Actions", so deployment goes through the
+# official pages artifact flow — no gh-pages branch.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - ".github/workflows/docs.yml"
+  pull_request:
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - ".github/workflows/docs.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install MkDocs
+        # Material pins a compatible MkDocs; the upper bounds keep CI off
+        # future majors (MkDocs 2.0 is currently unlicensed — see the
+        # mkdocs-material 2026-02-18 advisory) until deliberately bumped.
+        run: pip install "mkdocs-material>=9.7,<10" "mkdocs-static-i18n>=1.3,<2"
+
+      - name: Build site (strict)
+        run: mkdocs build --strict
+
+      - name: Upload Pages artifact
+        if: github.event_name == 'push'
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: site
+
+  deploy:
+    if: github.event_name == 'push'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ staging/
 
 # バックアップ
 *~
+
+# MkDocs build output
+site/

--- a/README.ja.md
+++ b/README.ja.md
@@ -150,7 +150,7 @@ eval "$(register-python-argcomplete speedtest-z)"
 
 設定ファイルは以下の順序で探索されます（`-c` / `--config` で明示指定も可能）：
 
-1. CLI で指定されたパス（`-c` / `--config`）
+1. CLI で指定されたパス（`-c` / `--config`。指定したファイルが存在しない場合、他の場所へのフォールバックは行われません）
 2. カレントディレクトリの `./config.ini`
 3. `~/.config/speedtest-z/config.ini`（XDG_CONFIG_HOME）
 4. `/etc/speedtest-z/config.ini`（システム全体、`.deb` パッケージで使用）
@@ -248,6 +248,7 @@ speedtest-z [options] [site ...]
 | オプション | 説明 |
 |-----------|------|
 | `-V`, `--version` | バージョン表示 |
+| `-m`, `--man` | マニュアル（README）をページャで表示して終了 |
 | `-c`, `--config CONFIG` | 設定ファイル指定 |
 | `-n`, `--dry-run` | テスト実行（Zabbix へ送信しない） |
 | `--headless` | ヘッドレスモードで実行 |
@@ -411,7 +412,7 @@ sudo cp deploy/speedtest-z.timer /etc/systemd/system/
 # 必要に応じてサービスファイルの ExecStart パスを編集
 sudo systemctl daemon-reload
 
-# タイマーを有効化・起動（6分間隔で実行）
+# タイマーを有効化・起動（10分間隔で実行）
 sudo systemctl enable --now speedtest-z.timer
 
 # 動作確認

--- a/README.ja.md
+++ b/README.ja.md
@@ -4,7 +4,7 @@
 [![CI](https://github.com/shigechika/speedtest-z/actions/workflows/ci.yml/badge.svg)](https://github.com/shigechika/speedtest-z/actions/workflows/ci.yml)
 [![Python](https://img.shields.io/pypi/pyversions/speedtest-z)](https://pypi.org/project/speedtest-z/)
 
-[English](https://github.com/shigechika/speedtest-z/blob/main/README.md)
+[English](https://github.com/shigechika/speedtest-z/blob/main/README.md) | [ドキュメント](https://shigechika.github.io/speedtest-z/ja/)
 
 speedtest-z は Web ブラウザで主要な速度テストサイトを自動巡回。ユーザ体験そのままの回線品質を定点観測できます。
 

--- a/README.md
+++ b/README.md
@@ -162,11 +162,12 @@ Add the `eval` line to your shell profile (`~/.bashrc` or `~/.zshrc`) to enable 
 
 ### config.ini
 
-The configuration file is searched in the following order (`-c` / `--config` can override):
+The configuration file is searched in the following order:
 
-1. `./config.ini` in the current directory
-2. `~/.config/speedtest-z/config.ini` (XDG_CONFIG_HOME)
-3. `/etc/speedtest-z/config.ini` (system-wide, used by `.deb` package)
+1. Path given with `-c` / `--config` (used as-is; if the file does not exist, there is no fallback to the other locations)
+2. `./config.ini` in the current directory
+3. `~/.config/speedtest-z/config.ini` (XDG_CONFIG_HOME)
+4. `/etc/speedtest-z/config.ini` (system-wide, used by `.deb` package)
 
 Copy `config.ini-sample` to one of these locations and edit as needed.
 
@@ -247,6 +248,7 @@ speedtest-z [options] [site ...]
 | Option | Description |
 |--------|-------------|
 | `-V`, `--version` | Show program version and exit |
+| `-m`, `--man` | Show the manual (README) in a pager and exit |
 | `-c`, `--config CONFIG` | Config file path (default: `./config.ini` or `~/.config/speedtest-z/config.ini`) |
 | `-n`, `--dry-run` | Test run (do not send data to Zabbix) |
 | `--headless` | Run Chrome in headless mode |
@@ -400,24 +402,26 @@ For manual (pip) installations, the `deploy/` directory contains systemd unit fi
 
 | File | Description |
 |------|-------------|
-| `speedtest-z.service` | Service unit (runs `speedtest-z` from the venv) |
-| `speedtest-z.timer` | Timer unit (runs every 6 minutes) |
+| `speedtest-z.service` | Service unit (runs `speedtest-z` as the `speedtest-z` user -- edit `ExecStart` / `User` to match your setup) |
+| `speedtest-z.timer` | Timer unit (runs every 10 minutes) |
 | `SeleniumCleaner.cron` | Cron job to clean up stale Chrome temp files |
 
 ### Setup
 
+The service unit sets `User=` / `Group=`, so install it as a **system** unit (user units under `~/.config/systemd/user/` cannot switch users and will fail):
+
 ```bash
 # Copy unit files
-cp deploy/speedtest-z.service ~/.config/systemd/user/
-cp deploy/speedtest-z.timer ~/.config/systemd/user/
+sudo cp deploy/speedtest-z.service /etc/systemd/system/
+sudo cp deploy/speedtest-z.timer /etc/systemd/system/
 
-# Reload and enable
-systemctl --user daemon-reload
-systemctl --user enable --now speedtest-z.timer
+# Edit the ExecStart path / User for your environment, then:
+sudo systemctl daemon-reload
+sudo systemctl enable --now speedtest-z.timer
 
 # Check status
-systemctl --user status speedtest-z.timer
-systemctl --user list-timers
+systemctl status speedtest-z.timer
+systemctl list-timers speedtest-z.timer
 ```
 
 Optionally, install the cron job for cleaning up stale Chrome temporary directories:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![CI](https://github.com/shigechika/speedtest-z/actions/workflows/ci.yml/badge.svg)](https://github.com/shigechika/speedtest-z/actions/workflows/ci.yml)
 [![Python](https://img.shields.io/pypi/pyversions/speedtest-z)](https://pypi.org/project/speedtest-z/)
 
-[日本語版 / Japanese](https://github.com/shigechika/speedtest-z/blob/main/README.ja.md)
+[日本語版 / Japanese](https://github.com/shigechika/speedtest-z/blob/main/README.ja.md) | [Documentation](https://shigechika.github.io/speedtest-z/)
 
 speedtest-z automates major speed test sites with a web browser, capturing real user-experience network quality for continuous monitoring.
 

--- a/docs/configuration.ja.md
+++ b/docs/configuration.ja.md
@@ -1,0 +1,92 @@
+# 設定ファイル
+
+## config.ini
+
+設定ファイルは以下の順序で探索されます（`-c` / `--config` で明示指定も可能）：
+
+1. CLI で指定されたパス（`-c` / `--config`）
+2. カレントディレクトリの `./config.ini`
+3. `~/.config/speedtest-z/config.ini`（XDG_CONFIG_HOME）
+4. `/etc/speedtest-z/config.ini`（システム全体、`.deb` パッケージで使用）
+
+`config.ini-sample` をコピーして編集してください。
+
+### `[general]` セクション
+
+```ini
+[general]
+# 実行モード設定
+dry_run = true          # true にすると外部送信しない（旧名 dryrun も互換サポート）
+headless = false        # ヘッドレスモード（GUI なし）
+timeout = 30            # 各テストのタイムアウト（秒）
+# ookla_server = IPA CyberLab 400G   # Ookla テストサーバ（省略時: 自動選択）
+```
+
+### `[zabbix]` セクション
+
+```ini
+[zabbix]
+enable = false           # true にすると Zabbix へ送信する
+server = 127.0.0.1       # 送信先 Zabbix Server
+port = 10051             # Zabbix トラッパーポート
+host = speedtest-agent   # Zabbix ホスト名
+# 任意: バージョンを host tag（speedtest-z=<version>）として Zabbix API 経由で付与。
+# speedtest-z[zabbix-api] が必要。api_url/api_user/api_password の3つすべて設定すると有効。
+# api_url = https://zabbix.example.com/api_jsonrpc.php
+# api_user = api-user
+# api_password = api-pass
+```
+
+### `[grafana]` セクション（オプション）
+
+```ini
+[grafana]
+enable = false
+remote_write_url = https://prometheus-prod-XX-prod-XX.grafana.net/api/prom/push
+username = <Prometheus ユーザ名>
+token = <Grafana Cloud API トークン>
+```
+
+### `[otel]` セクション（オプション）
+
+```ini
+[otel]
+enable = false
+endpoint = https://otlp-gateway-prod-XX.grafana.net/otlp
+# カンマ区切りの Key=Value ペア（OTEL_EXPORTER_OTLP_HEADERS と同じ形式）
+headers = Authorization=Basic <base64エンコード済み認証情報>
+```
+
+### `[snapshot]` セクション
+
+```ini
+[snapshot]
+enable = true            # 画面キャプチャの有効/無効
+save_dir = ./snapshots   # スクリーンショット保存先
+```
+
+### `[frequency]` セクション
+
+各サイトの実行確率を 0〜100 で設定します。0 で無効化、100 で毎回実行、50 で約半分の確率で実行されます。
+
+```ini
+[frequency]
+cloudflare = 100
+netflix = 100
+google = 100
+ookla = 50
+boxtest = 50
+mlab = 10
+usen = 50
+inonius = 50
+```
+
+## logging.ini
+
+`config.ini` と同じ探索順で検索されます（任意）：
+
+1. カレントディレクトリの `./logging.ini`
+2. `~/.config/speedtest-z/logging.ini`（XDG_CONFIG_HOME）
+3. `/etc/speedtest-z/logging.ini`（システム全体）
+
+いずれも見つからない場合は、デフォルトのログ設定（INFO レベル、stdout 出力）が使用されます。

--- a/docs/configuration.ja.md
+++ b/docs/configuration.ja.md
@@ -4,7 +4,7 @@
 
 設定ファイルは以下の順序で探索されます（`-c` / `--config` で明示指定も可能）：
 
-1. CLI で指定されたパス（`-c` / `--config`）
+1. CLI で指定されたパス（`-c` / `--config`。指定したファイルが存在しない場合、他の場所へのフォールバックは行われません）
 2. カレントディレクトリの `./config.ini`
 3. `~/.config/speedtest-z/config.ini`（XDG_CONFIG_HOME）
 4. `/etc/speedtest-z/config.ini`（システム全体、`.deb` パッケージで使用）

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,77 @@
+# Configuration
+
+## config.ini
+
+The configuration file is searched in the following order (`-c` / `--config` can override):
+
+1. `./config.ini` in the current directory
+2. `~/.config/speedtest-z/config.ini` (XDG_CONFIG_HOME)
+3. `/etc/speedtest-z/config.ini` (system-wide, used by `.deb` package)
+
+Copy `config.ini-sample` to one of these locations and edit as needed.
+
+### Sections
+
+```ini
+[general]
+# Run mode
+dry_run = true         # true = do not send data to backends
+headless = false       # true = run Chrome in headless mode
+timeout = 30           # timeout in seconds for each test
+# ookla_server = IPA CyberLab 400G   # Ookla test server (omit for auto-select)
+
+[zabbix]
+# Zabbix server settings
+enable = false           # true = send results to Zabbix
+server = 127.0.0.1
+port = 10051
+host = speedtest-agent   # Zabbix host name for trapper items
+# Optional: stamp the version as a host tag (speedtest-z=<version>) via the
+# Zabbix API. Requires speedtest-z[zabbix-api]; all three must be set.
+# api_url = https://zabbix.example.com/api_jsonrpc.php
+# api_user = api-user
+# api_password = api-pass
+
+[snapshot]
+# Screenshot capture settings
+enable = true
+save_dir = ./snapshots
+
+[frequency]
+# Execution probability per site (0-100)
+# 100 = always run, 50 = ~50% chance, 0 = disabled
+cloudflare = 100
+netflix = 100
+google = 100
+ookla = 50
+boxtest = 50
+mlab = 10
+usen = 50
+inonius = 50
+
+# [grafana]
+# # Grafana Cloud Prometheus Remote Write
+# enable = false
+# remote_write_url = https://prometheus-prod-XX-prod-XX.grafana.net/api/prom/push
+# username =
+# token =
+
+# [otel]
+# # OpenTelemetry (OTLP) metrics export
+# enable = false
+# endpoint = https://otlp-gateway-prod-XX.grafana.net/otlp
+# # Comma-separated Key=Value pairs (same format as OTEL_EXPORTER_OTLP_HEADERS)
+# headers = Authorization=Basic <base64-encoded-credentials>
+```
+
+> **Note:** The `dryrun` key (without underscore) is still supported for backward compatibility but `dry_run` is preferred.
+
+## logging.ini
+
+An optional `logging.ini` file can be used to customize log output. The file is searched in the same order as `config.ini`:
+
+1. `./logging.ini` in the current directory
+2. `~/.config/speedtest-z/logging.ini` (XDG_CONFIG_HOME)
+3. `/etc/speedtest-z/logging.ini` (system-wide)
+
+If none is found, the default logging configuration (INFO level to stdout) is used.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,11 +2,12 @@
 
 ## config.ini
 
-The configuration file is searched in the following order (`-c` / `--config` can override):
+The configuration file is searched in the following order:
 
-1. `./config.ini` in the current directory
-2. `~/.config/speedtest-z/config.ini` (XDG_CONFIG_HOME)
-3. `/etc/speedtest-z/config.ini` (system-wide, used by `.deb` package)
+1. Path given with `-c` / `--config` (used as-is; if the file does not exist, there is no fallback to the other locations)
+2. `./config.ini` in the current directory
+3. `~/.config/speedtest-z/config.ini` (XDG_CONFIG_HOME)
+4. `/etc/speedtest-z/config.ini` (system-wide, used by `.deb` package)
 
 Copy `config.ini-sample` to one of these locations and edit as needed.
 

--- a/docs/deployment.ja.md
+++ b/docs/deployment.ja.md
@@ -1,0 +1,29 @@
+# デプロイ（systemd）
+
+> **Note:** `.deb` / `.rpm` パッケージには systemd service/timer が同梱されています。インストール後 `sudo systemctl enable --now speedtest-z.timer` で有効化するだけです。
+
+pip でインストールした場合は、`deploy/` ディレクトリに systemd のサービスファイルとタイマーファイルが含まれています。
+
+```bash
+# サービスファイルとタイマーファイルをコピー
+sudo cp deploy/speedtest-z.service /etc/systemd/system/
+sudo cp deploy/speedtest-z.timer /etc/systemd/system/
+
+# 必要に応じてサービスファイルの ExecStart パスを編集
+sudo systemctl daemon-reload
+
+# タイマーを有効化・起動（6分間隔で実行）
+sudo systemctl enable --now speedtest-z.timer
+
+# 動作確認
+systemctl status speedtest-z.timer
+systemctl list-timers speedtest-z.timer
+```
+
+## Selenium クリーナー（cron）
+
+Chrome の一時ファイルを定期的に削除する cron 設定も含まれています。
+
+```bash
+sudo cp deploy/SeleniumCleaner.cron /etc/cron.d/SeleniumCleaner
+```

--- a/docs/deployment.ja.md
+++ b/docs/deployment.ja.md
@@ -12,7 +12,7 @@ sudo cp deploy/speedtest-z.timer /etc/systemd/system/
 # 必要に応じてサービスファイルの ExecStart パスを編集
 sudo systemctl daemon-reload
 
-# タイマーを有効化・起動（6分間隔で実行）
+# タイマーを有効化・起動（10分間隔で実行）
 sudo systemctl enable --now speedtest-z.timer
 
 # 動作確認

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,33 @@
+# Deployment (systemd)
+
+> **Note:** The `.deb` and `.rpm` packages include systemd service/timer files pre-configured. Just run `sudo systemctl enable --now speedtest-z.timer` after installing.
+
+For manual (pip) installations, the `deploy/` directory contains systemd unit files for scheduled execution:
+
+| File | Description |
+|------|-------------|
+| `speedtest-z.service` | Service unit (runs `speedtest-z` from the venv) |
+| `speedtest-z.timer` | Timer unit (runs every 6 minutes) |
+| `SeleniumCleaner.cron` | Cron job to clean up stale Chrome temp files |
+
+## Setup
+
+```bash
+# Copy unit files
+cp deploy/speedtest-z.service ~/.config/systemd/user/
+cp deploy/speedtest-z.timer ~/.config/systemd/user/
+
+# Reload and enable
+systemctl --user daemon-reload
+systemctl --user enable --now speedtest-z.timer
+
+# Check status
+systemctl --user status speedtest-z.timer
+systemctl --user list-timers
+```
+
+Optionally, install the cron job for cleaning up stale Chrome temporary directories:
+
+```bash
+sudo cp deploy/SeleniumCleaner.cron /etc/cron.d/SeleniumCleaner
+```

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -6,24 +6,26 @@ For manual (pip) installations, the `deploy/` directory contains systemd unit fi
 
 | File | Description |
 |------|-------------|
-| `speedtest-z.service` | Service unit (runs `speedtest-z` from the venv) |
-| `speedtest-z.timer` | Timer unit (runs every 6 minutes) |
+| `speedtest-z.service` | Service unit (runs `speedtest-z` as the `speedtest-z` user -- edit `ExecStart` / `User` to match your setup) |
+| `speedtest-z.timer` | Timer unit (runs every 10 minutes) |
 | `SeleniumCleaner.cron` | Cron job to clean up stale Chrome temp files |
 
 ## Setup
 
+The service unit sets `User=` / `Group=`, so install it as a **system** unit (user units under `~/.config/systemd/user/` cannot switch users and will fail):
+
 ```bash
 # Copy unit files
-cp deploy/speedtest-z.service ~/.config/systemd/user/
-cp deploy/speedtest-z.timer ~/.config/systemd/user/
+sudo cp deploy/speedtest-z.service /etc/systemd/system/
+sudo cp deploy/speedtest-z.timer /etc/systemd/system/
 
-# Reload and enable
-systemctl --user daemon-reload
-systemctl --user enable --now speedtest-z.timer
+# Edit the ExecStart path / User for your environment, then:
+sudo systemctl daemon-reload
+sudo systemctl enable --now speedtest-z.timer
 
 # Check status
-systemctl --user status speedtest-z.timer
-systemctl --user list-timers
+systemctl status speedtest-z.timer
+systemctl list-timers speedtest-z.timer
 ```
 
 Optionally, install the cron job for cleaning up stale Chrome temporary directories:

--- a/docs/index.ja.md
+++ b/docs/index.ja.md
@@ -1,0 +1,39 @@
+# speedtest-z
+
+speedtest-z は Web ブラウザで主要な速度テストサイトを自動巡回。ユーザ体験そのままの回線品質を定点観測できます。
+
+- 8つの速度テストサイトに対応（Cloudflare, Netflix, Ookla, M-Lab 等）
+- Zabbix 連携で回線品質を継続監視
+- `pip install speedtest-z` ですぐ使える
+
+![デモ - 8サイト速度テスト結果](demo.gif)
+
+導入は[インストール](install.md)、CLI の使い方は[使い方](usage.md)へ。
+
+## 特徴
+
+- 8つの速度テストサイトを自動実行（Cloudflare, Netflix/fast.com, Google Fiber, Ookla, Box-test, M-Lab, USEN, iNonius）
+- Zabbixへトラッパーアイテムとして結果送信（[zappix](https://pypi.org/project/zappix/) 使用）
+- Grafana Cloud 連携（Prometheus Remote Write、オプション）
+- OpenTelemetry (OTLP) メトリクス送信（オプション）
+- サイトごとの実行頻度設定（確率ベースのスロットリング）
+- デバッグ用スクリーンショット保存
+- ヘッドレス/GUI Chromeモード切替
+- CLI対応（`--dry-run`、サイト指定等）
+- systemd timerによるスケジュール実行
+
+## 計測結果を共有しませんか？
+
+爆速回線や激遅 Wi-Fi の計測結果をお待ちしています！
+
+[GitHub Issues](https://github.com/shigechika/speedtest-z/issues/new?template=speedtest-result.yml) から以下を添えて投稿してください:
+- `snapshots/` ディレクトリのスクリーンショット
+- CLI ログ出力（`speedtest-z --dry-run`）
+
+データセンターの超高速回線でも、山小屋の激遅 Wi-Fi でも大歓迎です。
+
+## License
+
+[Apache License 2.0](https://github.com/shigechika/speedtest-z/blob/main/LICENSE)
+
+Copyright 2026 AIKAWA Shigechika

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,39 @@
+# speedtest-z
+
+speedtest-z automates major speed test sites with a web browser, capturing real user-experience network quality for continuous monitoring.
+
+- Supports 8 speed test sites (Cloudflare, Netflix, Ookla, M-Lab, and more)
+- Zabbix integration for continuous network quality monitoring
+- Quick start: `pip install speedtest-z`
+
+![Demo - 8 speed test sites](demo.gif)
+
+See [Installation](install.md) to get started, and [Usage](usage.md) for the CLI.
+
+## Features
+
+- Runs speed tests on 8 different sites automatically (Cloudflare, Netflix/fast.com, Google Fiber, Ookla, Box-test, M-Lab, USEN, iNonius)
+- Sends results to Zabbix via trapper items (using [zappix](https://pypi.org/project/zappix/))
+- Optional Grafana Cloud integration via Prometheus Remote Write
+- Optional OpenTelemetry (OTLP) metrics export
+- Configurable test frequency per site (probability-based throttling)
+- Screenshot capture for debugging
+- Headless or GUI Chrome mode
+- CLI with `--dry-run`, site selection, etc.
+- systemd timer integration for scheduled execution
+
+## Share Your Results!
+
+Got the fastest or slowest speed test result? We'd love to see it!
+
+Submit your results via [GitHub Issues](https://github.com/shigechika/speedtest-z/issues/new?template=speedtest-result.yml) with:
+- Screenshot(s) from the `snapshots/` directory
+- CLI log output (`speedtest-z --dry-run`)
+
+Whether it's blazing fast datacenter fiber or painfully slow hotel Wi-Fi, all results are welcome.
+
+## License
+
+[Apache License 2.0](https://github.com/shigechika/speedtest-z/blob/main/LICENSE)
+
+Copyright 2026 AIKAWA Shigechika

--- a/docs/install.ja.md
+++ b/docs/install.ja.md
@@ -1,0 +1,117 @@
+# インストール
+
+## 前提条件
+
+- Python >= 3.10
+- Google Chrome ブラウザ（pip ではインストールされません）
+
+## Homebrew (macOS)
+
+```bash
+brew install shigechika/tap/speedtest-z
+```
+
+macOS Sonoma (14) / Sequoia (15) の Apple Silicon 向けにビルド済み bottle が提供されており、数秒でインストールが完了します。
+
+## Debian / Ubuntu (.deb)
+
+[GitHub Releases](https://github.com/shigechika/speedtest-z/releases) からディストリビューションに合った `.deb` パッケージをダウンロード:
+
+```bash
+# Ubuntu 24.04 (Noble)
+sudo dpkg -i speedtest-z_*~noble.deb
+
+# Ubuntu 22.04 (Jammy)
+sudo dpkg -i speedtest-z_*~jammy.deb
+```
+
+`.deb` パッケージは Python 依存をすべて含む自己完結型 virtualenv（`/opt/venvs/speedtest-z/`）、systemd service/timer（無効状態でインストール）、設定ファイル（`/etc/speedtest-z/`）を含みます。
+
+```bash
+# 設定を編集
+sudo vi /etc/speedtest-z/config.ini
+
+# スケジュール実行を有効化（10分間隔）
+sudo systemctl enable --now speedtest-z.timer
+```
+
+## RHEL / Rocky Linux / AlmaLinux (.rpm)
+
+[GitHub Releases](https://github.com/shigechika/speedtest-z/releases) から `.rpm` パッケージをダウンロード:
+
+```bash
+# RHEL 9 / Rocky Linux 9 / AlmaLinux 9
+sudo dnf install python3.11
+sudo rpm -ivh speedtest-z-*-1.el9.x86_64.rpm
+```
+
+`.rpm` パッケージは `.deb` と同様の構成です: `/opt/venvs/speedtest-z/` に自己完結型 virtualenv、systemd service/timer、設定ファイル（`/etc/speedtest-z/`）を含みます。
+
+## pip / uv
+
+```bash
+pip install speedtest-z
+
+# uv を使う場合
+uv tool install speedtest-z
+```
+
+## 開発用インストール
+
+```bash
+git clone https://github.com/shigechika/speedtest-z.git
+cd speedtest-z
+python3 -m venv .venv
+. .venv/bin/activate
+pip install -e .
+
+# uv を使う場合
+uv sync
+```
+
+## 依存ライブラリ
+
+- [selenium](https://pypi.org/project/selenium/) — ブラウザ自動操作
+- [zappix](https://pypi.org/project/zappix/) — Zabbix トラッパー送信
+
+## Grafana Cloud 対応（オプション）
+
+```bash
+pip install speedtest-z[grafana]
+
+# uv を使う場合
+uv tool install "speedtest-z[grafana]"
+```
+
+Prometheus Remote Write に必要な Snappy 圧縮ライブラリ `cramjam` がインストールされます。
+
+## OpenTelemetry 対応（オプション）
+
+```bash
+pip install speedtest-z[otel]
+
+# uv を使う場合
+uv tool install "speedtest-z[otel]"
+```
+
+OpenTelemetry SDK と OTLP HTTP エクスポーターがインストールされます。
+
+## Zabbix ホストバージョンタグ（オプション）
+
+```bash
+pip install speedtest-z[zabbix-api]
+
+# uv を使う場合
+uv tool install "speedtest-z[zabbix-api]"
+```
+
+[zapi-lib](https://github.com/shigechika/zapi-lib) がインストールされ、トラッパー送信に加えて、実行中の speedtest-z バージョンを Zabbix API 経由で host tag（`speedtest-z=<version>`）として付与できます。`[zabbix]` セクションの `api_url` / `api_user` / `api_password` を設定すると有効になります。`api_url` は https を推奨し、`config.ini` は所有者のみ読めるよう権限を制限してください（パスワードは平文で保存されます）。Zabbix API ユーザーは最小権限（`host.update` のみ）を推奨します。
+
+## タブ補完（任意）
+
+```bash
+pip install speedtest-z[completion]
+eval "$(register-python-argcomplete speedtest-z)"
+```
+
+`eval` の行を `~/.bashrc` や `~/.zshrc` に追記すると常時有効になります。

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,117 @@
+# Installation
+
+## Prerequisites
+
+- Python >= 3.10
+- Google Chrome browser (not installable via pip -- must be installed separately)
+
+## Homebrew (macOS)
+
+```bash
+brew install shigechika/tap/speedtest-z
+```
+
+Pre-built bottles are available for macOS Sonoma (14) and Sequoia (15) on Apple Silicon. Installation completes in seconds.
+
+## Debian / Ubuntu (.deb)
+
+Download the `.deb` package for your distribution from [GitHub Releases](https://github.com/shigechika/speedtest-z/releases):
+
+```bash
+# Ubuntu 24.04 (Noble)
+sudo dpkg -i speedtest-z_*~noble.deb
+
+# Ubuntu 22.04 (Jammy)
+sudo dpkg -i speedtest-z_*~jammy.deb
+```
+
+The `.deb` package includes all Python dependencies in a self-contained virtualenv (`/opt/venvs/speedtest-z/`), systemd service/timer (installed disabled), and config files in `/etc/speedtest-z/`.
+
+```bash
+# Edit config
+sudo vi /etc/speedtest-z/config.ini
+
+# Enable scheduled execution (every 10 minutes)
+sudo systemctl enable --now speedtest-z.timer
+```
+
+## RHEL / Rocky Linux / AlmaLinux (.rpm)
+
+Download the `.rpm` package from [GitHub Releases](https://github.com/shigechika/speedtest-z/releases):
+
+```bash
+# RHEL 9 / Rocky Linux 9 / AlmaLinux 9
+sudo dnf install python3.11
+sudo rpm -ivh speedtest-z-*-1.el9.x86_64.rpm
+```
+
+The `.rpm` package has the same structure as the `.deb` package: self-contained virtualenv in `/opt/venvs/speedtest-z/`, systemd service/timer, and config files in `/etc/speedtest-z/`.
+
+## pip / uv
+
+```bash
+pip install speedtest-z
+
+# or using uv
+uv tool install speedtest-z
+```
+
+## Development Setup
+
+```bash
+git clone https://github.com/shigechika/speedtest-z.git
+cd speedtest-z
+python3 -m venv .venv
+. .venv/bin/activate
+pip install -e .
+
+# or using uv
+uv sync
+```
+
+## Dependencies
+
+- [selenium](https://pypi.org/project/selenium/) -- Browser automation
+- [zappix](https://pypi.org/project/zappix/) -- Zabbix sender protocol
+
+## Grafana Cloud Support (optional)
+
+```bash
+pip install speedtest-z[grafana]
+
+# or using uv
+uv tool install "speedtest-z[grafana]"
+```
+
+This installs `cramjam` for Snappy compression required by Prometheus Remote Write.
+
+## OpenTelemetry Support (optional)
+
+```bash
+pip install speedtest-z[otel]
+
+# or using uv
+uv tool install "speedtest-z[otel]"
+```
+
+This installs the OpenTelemetry SDK and OTLP HTTP exporter for sending metrics via OTLP.
+
+## Zabbix Host Version Tag (optional)
+
+```bash
+pip install speedtest-z[zabbix-api]
+
+# or using uv
+uv tool install "speedtest-z[zabbix-api]"
+```
+
+This installs [zapi-lib](https://github.com/shigechika/zapi-lib) so speedtest-z can stamp its running version onto the Zabbix host as a tag (`speedtest-z=<version>`) via the Zabbix JSON-RPC API, alongside the trapper send path. Set `api_url` / `api_user` / `api_password` under `[zabbix]` to enable it. Use an `https` `api_url`, keep `config.ini` readable only by its owner (the password is stored in plaintext), and prefer a least-privilege Zabbix API user (`host.update` only).
+
+## Tab Completion (optional)
+
+```bash
+pip install speedtest-z[completion]
+eval "$(register-python-argcomplete speedtest-z)"
+```
+
+Add the `eval` line to your shell profile (`~/.bashrc` or `~/.zshrc`) to enable it permanently.

--- a/docs/integrations.ja.md
+++ b/docs/integrations.ja.md
@@ -1,0 +1,55 @@
+# 連携
+
+speedtest-z は有効化した全バックエンド（Zabbix・Grafana Cloud・OTLP 対応バックエンド）へ結果を送信します。
+
+## Zabbix連携
+
+`speedtest-z_templates.yaml` を Zabbix にインポートすると、全テストサイトのアイテムが自動作成されます。
+
+- 全アイテムはトラッパータイプ（`type: TRAP`）
+- 速度系アイテムは Mbps → bps への前処理（MULTIPLIER x1000000）付き
+- `config.ini` の `[zabbix]` セクションで `enable = true` に設定
+
+## Grafana Cloud 連携
+
+![Grafana ダッシュボード](grafana.png)
+
+Prometheus Remote Write 経由で Grafana Cloud にメトリクスを送信できます。
+
+1. Grafana 対応をインストール: `pip install speedtest-z[grafana]`
+2. `config.ini` に `[grafana]` セクションを追加:
+
+```ini
+[grafana]
+enable = true
+remote_write_url = https://prometheus-prod-XX-prod-XX.grafana.net/api/prom/push
+username = <Prometheus ユーザ名>
+token = <Grafana Cloud API トークン>
+```
+
+3. メトリクスは `speedtest_<metric>{site="<site>"}` の形式で送信されます（例: `speedtest_download{site="cloudflare"}`）
+4. Zabbix と Grafana は同時に有効化でき、計測結果は全ての有効なバックエンドに送信されます
+
+```bash
+# Zabbix Web UI → 設定 → テンプレート → インポート
+# speedtest-z_templates.yaml を選択してインポート
+```
+
+## OpenTelemetry (OTLP) 連携
+
+OpenTelemetry Protocol (OTLP) 経由で OTLP 対応バックエンドにメトリクスを送信できます。
+
+1. OTel 対応をインストール: `pip install speedtest-z[otel]`
+2. `config.ini` に `[otel]` セクションを追加:
+
+```ini
+[otel]
+enable = true
+endpoint = https://otlp-gateway-prod-XX.grafana.net/otlp
+headers = Authorization=Basic <base64エンコード済み認証情報>
+```
+
+3. メトリクスは `speedtest_<metric>{site="<site>", host="<host>"}` の形式で送信されます
+4. Zabbix、Grafana、OTel の3バックエンドを同時に有効化できます
+
+> **注意:** 2026年2月時点で、**無料プラン**で Collector なしの OTLP メトリクス直接取り込みに対応しているバックエンドは限られています。Grafana Cloud が最も成熟した選択肢です。Mackerel・GCP Cloud Monitoring・AWS CloudWatch は現状 OTLP トレースのみ対応、Datadog は組織のホワイトリスト登録が必要です。有料プランではより広い OTLP メトリクス対応が期待できます。

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,0 +1,49 @@
+# Integrations
+
+speedtest-z sends results to every enabled backend: Zabbix, Grafana Cloud, and any OTLP endpoint.
+
+## Zabbix Integration
+
+1. Import the `speedtest-z_templates.yaml` template into Zabbix.
+2. All items are **trapper** type -- the agent pushes data to Zabbix using the zappix sender protocol.
+3. Set `enable = true` in the `[zabbix]` section of `config.ini`.
+4. The `host` value in `config.ini` must match the host name registered in Zabbix.
+
+## Grafana Cloud Integration
+
+![Grafana Dashboard](grafana.png)
+
+speedtest-z can push metrics to Grafana Cloud via Prometheus Remote Write.
+
+1. Install with Grafana support: `pip install speedtest-z[grafana]`
+2. Add the `[grafana]` section to `config.ini`:
+
+```ini
+[grafana]
+enable = true
+remote_write_url = https://prometheus-prod-XX-prod-XX.grafana.net/api/prom/push
+username = <your-prometheus-username>
+token = <your-grafana-cloud-api-token>
+```
+
+3. Metrics are sent as `speedtest_<metric>` with a `site` label (e.g., `speedtest_download{site="cloudflare"}`).
+4. Both Zabbix and Grafana can be enabled simultaneously -- results are sent to all enabled backends.
+
+## OpenTelemetry (OTLP) Integration
+
+speedtest-z can export metrics via OpenTelemetry Protocol (OTLP) to any OTLP-compatible backend.
+
+1. Install with OTel support: `pip install speedtest-z[otel]`
+2. Add the `[otel]` section to `config.ini`:
+
+```ini
+[otel]
+enable = true
+endpoint = https://otlp-gateway-prod-XX.grafana.net/otlp
+headers = Authorization=Basic <base64-encoded-credentials>
+```
+
+3. Metrics are sent as `speedtest_<metric>` with `site` and `host` labels.
+4. All three backends (Zabbix, Grafana, OTel) can be enabled simultaneously.
+
+> **Note:** As of Feb 2026, direct OTLP metrics ingestion (without a collector) on **free tier** accounts is supported by very few backends. Grafana Cloud is the most mature option. Mackerel, GCP Cloud Monitoring, and AWS CloudWatch currently support OTLP traces only; Datadog requires an allowlisted organization. Paid plans may offer broader OTLP metrics support.

--- a/docs/sites.ja.md
+++ b/docs/sites.ja.md
@@ -1,0 +1,16 @@
+# 対応テストサイト
+
+| サイト名 | URL | 取得メトリクス |
+|----------|-----|---------------|
+| `cloudflare` | https://speed.cloudflare.com/ | download, upload, latency, jitter |
+| `netflix` | https://fast.com/ | download, upload, latency, server-locations |
+| `google` | http://speed.googlefiber.net/ | download, upload, ping |
+| `ookla` | https://www.speedtest.net/ | download, upload, ping |
+| `boxtest` | https://www.box-test.com/ | POP, DownloadSpeed, DownloadDuration, DownloadRTT, UploadSpeed, UploadDuration, UploadRTT, latency |
+| `mlab` | https://speed.measurementlab.net/ | download, upload, latency, retrans |
+| `usen` | https://speedtest.gate02.ne.jp/ | download, upload, ping, jitter |
+| `inonius` | https://inonius.net/speedtest/ | IPv4/IPv6 各: DL, UL, RTT, JIT, MSS |
+
+> **注意: Google Fiber (speed.googlefiber.net) とジャンボフレーム**
+>
+> speed.googlefiber.net は HTTPS 非対応（HTTP のみ）で、AAAA レコードを持ちません。IPv6-only 環境では DNS64/NAT64 経由でアクセスしますが、**NIC の MTU が 9000（ジャンボフレーム）の場合、ページの JavaScript が読み込めず画面が真っ白になります**。MTU を 1500 に設定してください。

--- a/docs/sites.md
+++ b/docs/sites.md
@@ -1,0 +1,18 @@
+# Supported Test Sites
+
+| Site | URL | Metrics (Zabbix keys) |
+|------|-----|----------------------|
+| `cloudflare` | https://speed.cloudflare.com/ | download, upload, latency, jitter |
+| `netflix` | https://fast.com/ | download, upload, latency, server-locations |
+| `google` | http://speed.googlefiber.net/ | download, upload, ping |
+| `ookla` | https://www.speedtest.net/ | download, upload, ping |
+| `boxtest` | https://www.box-test.com/ | POP, DownloadSpeed, DownloadDuration, DownloadRTT, UploadSpeed, UploadDuration, UploadRTT, latency |
+| `mlab` | https://speed.measurementlab.net/ | download, upload, latency, retrans |
+| `usen` | https://speedtest.gate02.ne.jp/ | download, upload, ping, jitter |
+| `inonius` | https://inonius.net/speedtest/ | IPv4/IPv6: DL, UL, RTT, JIT, MSS |
+
+All Zabbix item keys are prefixed with the site name (e.g., `cloudflare.download`, `usen.ping`, `inonius.IPv4_DL`).
+
+> **Note: Google Fiber (speed.googlefiber.net) and jumbo frames**
+>
+> speed.googlefiber.net does not support HTTPS (HTTP only) and has no AAAA records. In IPv6-only environments it is accessed via DNS64/NAT64, but **if the NIC MTU is set to 9000 (jumbo frames), the page JavaScript fails to load and the screen stays blank**. Set the MTU to 1500.

--- a/docs/troubleshooting.ja.md
+++ b/docs/troubleshooting.ja.md
@@ -1,0 +1,12 @@
+# トラブルシューティング
+
+| 問題 | 解決策 |
+|------|--------|
+| Linux で USEN/iNonius のスナップショットが豆腐文字（□□□）になる | 日本語フォントをインストール: `sudo apt install fonts-noto-cjk` |
+| ChromeDriver のバージョン不一致エラー | Selenium Manager が自動でダウンロードします。`selenium` パッケージを更新: `pip install -U selenium` |
+| テストがハングする・タイムアウトする | タイムアウトを延長: `speedtest-z --timeout 60`、またはネットワーク接続を確認 |
+| `config.ini` が見つからない | `./`、`~/.config/speedtest-z/`、`/etc/speedtest-z/` のいずれかに配置。`config.ini-sample` からコピー |
+| Zabbix sender の接続が拒否される | `[zabbix]` セクションの `server` と `port` を確認、zabbix_sender への疎通を確認 |
+| Grafana Cloud で 401/403 エラー | `[grafana]` セクションの `token` のスコープを確認（`MetricsPublisher` ロールが必要） |
+| `ModuleNotFoundError: cramjam` | Grafana 対応をインストール: `pip install speedtest-z[grafana]` |
+| `ModuleNotFoundError: opentelemetry` | OTel 対応をインストール: `pip install speedtest-z[otel]` |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,12 @@
+# Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| Tofu characters (□□□) in USEN/iNonius snapshots on Linux | Install Japanese fonts: `sudo apt install fonts-noto-cjk` |
+| ChromeDriver version mismatch error | Selenium Manager auto-downloads the matching driver. Update `selenium` package: `pip install -U selenium` |
+| Site test hangs or times out | Increase timeout: `speedtest-z --timeout 60` or check your network |
+| `config.ini` not found | Place it in one of: `./`, `~/.config/speedtest-z/`, or `/etc/speedtest-z/`. Copy from `config.ini-sample` |
+| Zabbix sender connection refused | Verify `server` and `port` in `[zabbix]` section, ensure zabbix_sender is reachable |
+| Grafana Cloud 401/403 | Check `token` scope (needs `MetricsPublisher` role) in `[grafana]` section |
+| `ModuleNotFoundError: cramjam` | Install with Grafana support: `pip install speedtest-z[grafana]` |
+| `ModuleNotFoundError: opentelemetry` | Install with OTel support: `pip install speedtest-z[otel]` |

--- a/docs/usage.ja.md
+++ b/docs/usage.ja.md
@@ -9,6 +9,7 @@ speedtest-z [options] [site ...]
 | オプション | 説明 |
 |-----------|------|
 | `-V`, `--version` | バージョン表示 |
+| `-m`, `--man` | マニュアル（README）をページャで表示して終了 |
 | `-c`, `--config CONFIG` | 設定ファイル指定 |
 | `-n`, `--dry-run` | テスト実行（Zabbix へ送信しない） |
 | `--headless` | ヘッドレスモードで実行 |

--- a/docs/usage.ja.md
+++ b/docs/usage.ja.md
@@ -1,0 +1,90 @@
+# 使い方
+
+```
+speedtest-z [options] [site ...]
+```
+
+## CLIオプション
+
+| オプション | 説明 |
+|-----------|------|
+| `-V`, `--version` | バージョン表示 |
+| `-c`, `--config CONFIG` | 設定ファイル指定 |
+| `-n`, `--dry-run` | テスト実行（Zabbix へ送信しない） |
+| `--headless` | ヘッドレスモードで実行 |
+| `--no-headless`, `--headed` | GUI モードで実行 |
+| `--timeout SECONDS` | 各テストのタイムアウト（秒） |
+| `--list-sites` | 利用可能なテストサイト一覧を表示して終了 |
+| `--check` | テストサイト URL の疎通確認を行い終了（Chrome 不要） |
+| `-o`, `--output FORMAT` | 出力形式: `zabbix`（デフォルト）、`json`、`csv` |
+| `-d`, `--debug` | デバッグ出力を有効化 |
+| `site` | 実行するテストサイト（位置引数、省略時は全サイト） |
+
+## 確認プロンプト
+
+対話的なターミナル（TTY）から実行すると、テストサイトへの接続前に確認を求めます。cron や systemd、パイプ経由など非対話環境では自動的にスキップされます。
+
+```
+$ speedtest-z -n
+speedtest-z: 8 サイトに接続します (cloudflare, netflix, ...)
+続行しますか？ [y/N]: y
+```
+
+## 実行例
+
+```bash
+# 全サイトをテスト実行（Zabbix に送信しない）
+speedtest-z -n
+
+# 特定サイトのみ実行
+speedtest-z cloudflare netflix
+
+# GUI モードでデバッグ実行
+speedtest-z --no-headless -d google
+
+# 利用可能なサイト一覧を表示
+speedtest-z --list-sites
+
+# テストサイト URL の疎通確認（Chrome 不要）
+speedtest-z --check
+
+# 特定サイトのみ疎通確認
+speedtest-z --check cloudflare netflix
+
+# 結果を JSON で出力（Zabbix 送信はスキップ）
+speedtest-z --dry-run --output json cloudflare 2>/dev/null
+
+# 結果を CSV で出力
+speedtest-z --dry-run -o csv cloudflare netflix 2>/dev/null
+```
+
+## 実行ログの例
+
+```
+$ speedtest-z --dry-run
+speedtest-z: 8 サイトに接続します (cloudflare, netflix, google, ookla, boxtest, mlab, usen, inonius)
+続行しますか？ [y/N]: y
+2026-02-25 15:00:01 [INFO] speedtest-z: START
+2026-02-25 15:00:01 [INFO] Config loaded: config.ini
+2026-02-25 15:00:01 [INFO] Initializing Chrome WebDriver...
+2026-02-25 15:00:02 [INFO] cloudflare: OPEN
+2026-02-25 15:00:09 [INFO] cloudflare: Test started
+2026-02-25 15:00:58 [INFO] cloudflare: COMPLETED (Quality Scores appeared)
+2026-02-25 15:00:58 [INFO] netflix: OPEN
+2026-02-25 15:01:24 [INFO] netflix: COMPLETED (succeeded class detected)
+2026-02-25 15:01:24 [INFO] google: OPEN
+2026-02-25 15:01:51 [INFO] google: COMPLETED
+2026-02-25 15:01:51 [INFO] ookla: OPEN (Attempt 1/3)
+2026-02-25 15:02:31 [INFO] ookla: COMPLETED
+2026-02-25 15:02:33 [INFO] boxtest: OPEN
+2026-02-25 15:03:48 [INFO] boxtest: COMPLETED
+2026-02-25 15:03:48 [INFO] mlab: OPEN
+2026-02-25 15:04:36 [INFO] mlab: COMPLETED
+2026-02-25 15:04:36 [INFO] usen: OPEN
+2026-02-25 15:05:05 [INFO] usen: COMPLETED (speedtest_wait class removed)
+2026-02-25 15:05:05 [INFO] inonius: OPEN
+2026-02-25 15:06:02 [INFO] inonius: COMPLETED
+2026-02-25 15:06:02 [INFO] speedtest-z: FINISH
+```
+
+全8サイトの計測が約6分で完了しています。

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -9,6 +9,7 @@ speedtest-z [options] [site ...]
 | Option | Description |
 |--------|-------------|
 | `-V`, `--version` | Show program version and exit |
+| `-m`, `--man` | Show the manual (README) in a pager and exit |
 | `-c`, `--config CONFIG` | Config file path (default: `./config.ini` or `~/.config/speedtest-z/config.ini`) |
 | `-n`, `--dry-run` | Test run (do not send data to Zabbix) |
 | `--headless` | Run Chrome in headless mode |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,90 @@
+# Usage
+
+```
+speedtest-z [options] [site ...]
+```
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `-V`, `--version` | Show program version and exit |
+| `-c`, `--config CONFIG` | Config file path (default: `./config.ini` or `~/.config/speedtest-z/config.ini`) |
+| `-n`, `--dry-run` | Test run (do not send data to Zabbix) |
+| `--headless` | Run Chrome in headless mode |
+| `--no-headless`, `--headed` | Run Chrome with GUI (non-headless) |
+| `--timeout SECONDS` | Timeout in seconds for each test |
+| `--list-sites` | List available test sites and exit |
+| `--check` | Check site URL reachability and exit (no Chrome needed) |
+| `-o`, `--output FORMAT` | Output format: `zabbix` (default), `json`, `csv` |
+| `-d`, `--debug` | Enable debug output |
+| `site` | Positional argument(s): test site(s) to run (default: all) |
+
+## Confirmation Prompt
+
+When run from an interactive terminal (TTY), speedtest-z asks for confirmation before connecting to test sites. Non-interactive environments (cron, systemd, piped input) skip the prompt automatically.
+
+```
+$ speedtest-z -n
+speedtest-z: connecting to 8 site(s) (cloudflare, netflix, ...)
+Continue? [y/N]: y
+```
+
+## Examples
+
+```bash
+# Run all test sites (dry-run)
+speedtest-z -n
+
+# Run specific sites
+speedtest-z cloudflare netflix
+
+# Run with GUI browser for debugging
+speedtest-z --no-headless -d cloudflare
+
+# List available sites
+speedtest-z --list-sites
+
+# Check if all test site URLs are reachable (no Chrome needed)
+speedtest-z --check
+
+# Check specific sites only
+speedtest-z --check cloudflare netflix
+
+# Output results as JSON (Zabbix send is skipped)
+speedtest-z --dry-run --output json cloudflare 2>/dev/null
+
+# Output results as CSV
+speedtest-z --dry-run -o csv cloudflare netflix 2>/dev/null
+```
+
+## Example Output
+
+```
+$ speedtest-z --dry-run
+speedtest-z: connecting to 8 site(s) (cloudflare, netflix, google, ookla, boxtest, mlab, usen, inonius)
+Continue? [y/N]: y
+2026-02-25 15:00:01 [INFO] speedtest-z: START
+2026-02-25 15:00:01 [INFO] Config loaded: config.ini
+2026-02-25 15:00:01 [INFO] Initializing Chrome WebDriver...
+2026-02-25 15:00:02 [INFO] cloudflare: OPEN
+2026-02-25 15:00:09 [INFO] cloudflare: Test started
+2026-02-25 15:00:58 [INFO] cloudflare: COMPLETED (Quality Scores appeared)
+2026-02-25 15:00:58 [INFO] netflix: OPEN
+2026-02-25 15:01:24 [INFO] netflix: COMPLETED (succeeded class detected)
+2026-02-25 15:01:24 [INFO] google: OPEN
+2026-02-25 15:01:51 [INFO] google: COMPLETED
+2026-02-25 15:01:51 [INFO] ookla: OPEN (Attempt 1/3)
+2026-02-25 15:02:31 [INFO] ookla: COMPLETED
+2026-02-25 15:02:33 [INFO] boxtest: OPEN
+2026-02-25 15:03:48 [INFO] boxtest: COMPLETED
+2026-02-25 15:03:48 [INFO] mlab: OPEN
+2026-02-25 15:04:36 [INFO] mlab: COMPLETED
+2026-02-25 15:04:36 [INFO] usen: OPEN
+2026-02-25 15:05:05 [INFO] usen: COMPLETED (speedtest_wait class removed)
+2026-02-25 15:05:05 [INFO] inonius: OPEN
+2026-02-25 15:06:02 [INFO] inonius: COMPLETED
+2026-02-25 15:06:02 [INFO] speedtest-z: FINISH
+```
+
+All 8 sites completed in about 6 minutes.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,77 @@
+site_name: speedtest-z
+site_description: >-
+  Automated multi-site speed test runner — drives real browser speed tests
+  with Selenium and ships results to Zabbix, Grafana Cloud, or any OTLP
+  backend.
+site_url: https://shigechika.github.io/speedtest-z/
+repo_url: https://github.com/shigechika/speedtest-z
+repo_name: shigechika/speedtest-z
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.sections
+    - navigation.footer
+    - content.code.copy
+    - content.action.edit
+
+markdown_extensions:
+  - admonition
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.highlight
+  - pymdownx.inlinehilite
+  - pymdownx.tabbed:
+      alternate_style: true
+
+plugins:
+  - search
+  - i18n:
+      docs_structure: suffix
+      languages:
+        - locale: en
+          name: English
+          default: true
+          build: true
+        - locale: ja
+          name: 日本語
+          build: true
+          nav_translations:
+            Home: ホーム
+            Installation: インストール
+            Configuration: 設定ファイル
+            Usage: 使い方
+            Supported Test Sites: 対応テストサイト
+            Integrations: 連携
+            Deployment (systemd): デプロイ（systemd）
+            Troubleshooting: トラブルシューティング
+
+nav:
+  - Home: index.md
+  - Installation: install.md
+  - Configuration: configuration.md
+  - Usage: usage.md
+  - Supported Test Sites: sites.md
+  - Integrations: integrations.md
+  - Deployment (systemd): deployment.md
+  - Troubleshooting: troubleshooting.md


### PR DESCRIPTION
## Summary

- Split `README.md` / `README.ja.md` into an 8-page MkDocs Material site under `docs/` (Home / Installation / Configuration / Usage / Supported Test Sites / Integrations / Deployment / Troubleshooting), using the `mkdocs-static-i18n` suffix structure (English default + Japanese, language selector in the header).
- Reuse the proven `mkdocs.yml` + `.github/workflows/docs.yml` template from [shigechika/mcp-stdio](https://github.com/shigechika/mcp-stdio): `mkdocs build --strict` on every docs PR, deploy to GitHub Pages via the official Pages artifact flow (Source: GitHub Actions, no `gh-pages` branch) on push to main.
- `docs:` commits do not interfere with release-please.
- Link the published site from both READMEs; ignore the local `site/` build output.

## Test plan

- [x] `mkdocs build --strict` passes locally (no broken links, both locales build, nav translated to ja)
- [x] `demo.gif` / `grafana.png` resolve from the docs pages
- [ ] Docs workflow green on this PR
- [ ] After merge: site live at https://shigechika.github.io/speedtest-z/ (en) and /ja/ (ja)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSZ4DStF9gZzjfbcyT7pmX