### PR TITLE
fix: adapt ookla and mlab runners to site UI changes, exit 130 on Ctrl-C

### DIFF
--- a/speedtest_z/cli.py
+++ b/speedtest_z/cli.py
@@ -216,6 +216,7 @@ def main() -> None:
         app.sender.close()
         app.sender = OutputCollector(output_fmt)
 
+    interrupted = False
     try:
         site_runners = get_site_runners()
         for site in sites:
@@ -229,11 +230,17 @@ def main() -> None:
         app.stamp_version()
     except KeyboardInterrupt:
         logger.info("Interrupted by user")
+        interrupted = True
     except Exception:
         # Surface a non-zero exit code so systemd/cron can detect the failure.
         logger.exception("Fatal Error")
         sys.exit(1)
     finally:
         app.close()
+
+    if interrupted:
+        # 128 + SIGINT, the conventional exit code for Ctrl-C. Also skips the
+        # FINISH log line, which would misleadingly suggest a complete run.
+        sys.exit(130)
 
     logger.info("speedtest-z: FINISH")

--- a/speedtest_z/runner.py
+++ b/speedtest_z/runner.py
@@ -205,7 +205,11 @@ class SpeedtestZ:
             self.driver.save_screenshot(filepath)
             logger.debug(f"Snapshot saved: {filename}")
         except Exception as e:
-            logger.warning(f"Failed to take snapshot: {e}")
+            # Keep the WARNING to one short line: a dead driver (e.g. after
+            # Ctrl-C also killed Chrome) raises with a multi-line urllib3
+            # message. Full detail goes to DEBUG.
+            logger.warning(f"Failed to take snapshot: {type(e).__name__}")
+            logger.debug(f"Snapshot failure detail: {e}")
 
     def send_results(self, data_list: list[dict[str, str]]) -> None:
         """Send measurement results to enabled backends (Zabbix, Grafana, OTel).

--- a/speedtest_z/sites/mlab.py
+++ b/speedtest_z/sites/mlab.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 from selenium.common.exceptions import NoSuchElementException, TimeoutException
 from selenium.webdriver.common.by import By
@@ -20,18 +20,16 @@ logger = logging.getLogger("speedtest-z")
 
 URL = "https://speed.measurementlab.net/"
 
-# Data-policy consent checkbox: current site id first, legacy id as fallback
-CONSENT_IDS = ("privacyConsent", "demo-human")
+# Data-policy consent checkbox: current site id plus the legacy id
+CONSENT_SELECTOR = "#privacyConsent, #demo-human"
 
 
 def _find_consent(driver: WebDriver) -> WebElement | None:
     """Return the consent checkbox element, or None if not present."""
-    for consent_id in CONSENT_IDS:
-        try:
-            return driver.find_element(By.ID, consent_id)
-        except NoSuchElementException:
-            continue
-    return None
+    try:
+        return driver.find_element(By.CSS_SELECTOR, CONSENT_SELECTOR)
+    except NoSuchElementException:
+        return None
 
 
 def _consent_checked(driver: WebDriver) -> bool:
@@ -40,14 +38,14 @@ def _consent_checked(driver: WebDriver) -> bool:
     return chk_box is not None and chk_box.is_selected()
 
 
-def _enabled_start_button(driver: WebDriver) -> WebElement | Literal[False]:
+def _enabled_start_button(driver: WebDriver) -> WebElement | None:
     """Return the start button once it no longer carries the disabled class."""
     try:
         btn = driver.find_element(By.CSS_SELECTOR, "a.startButton")
     except NoSuchElementException:
-        return False
+        return None
     if "disabled" in (btn.get_attribute("class") or ""):
-        return False
+        return None
     return btn
 
 
@@ -63,15 +61,18 @@ def run_mlab(app: SpeedtestZ) -> None:
 
         if app.auto_consent:
             try:
-                chk_box = app.wait.until(lambda d: _find_consent(d))
-                app.driver.execute_script("arguments[0].click();", chk_box)
-                logger.info("mlab: Consent checked (auto)")
+                chk_box = app.wait.until(_find_consent)
+                if chk_box.is_selected():
+                    logger.info("mlab: Consent already checked")
+                else:
+                    app.driver.execute_script("arguments[0].click();", chk_box)
+                    logger.info("mlab: Consent checked (auto)")
             except TimeoutException:
                 logger.debug("mlab: Consent checkbox not found (auto)")
         else:
             # Wait for the user to click the checkbox
             try:
-                chk_box = WebDriverWait(app.driver, 5).until(lambda d: _find_consent(d))
+                chk_box = WebDriverWait(app.driver, 5).until(_find_consent)
                 if not chk_box.is_selected():
                     logger.info("mlab: Waiting for user to check consent checkbox...")
                     WebDriverWait(app.driver, 120).until(_consent_checked)

--- a/speedtest_z/sites/mlab.py
+++ b/speedtest_z/sites/mlab.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from selenium.common.exceptions import NoSuchElementException, TimeoutException
 from selenium.webdriver.common.by import By
@@ -24,28 +24,33 @@ URL = "https://speed.measurementlab.net/"
 CONSENT_SELECTOR = "#privacyConsent, #demo-human"
 
 
-def _find_consent(driver: WebDriver) -> WebElement | None:
-    """Return the consent checkbox element, or None if not present."""
+# Both wait predicates return Literal[False] (not None) for the miss case:
+# selenium's WebDriverWait.until() stubs narrow `Literal[False] | T` to `T`,
+# so False keeps mypy happy at the call sites while None would not.
+
+
+def _find_consent(driver: WebDriver) -> WebElement | Literal[False]:
+    """Return the consent checkbox element, or False if not present."""
     try:
         return driver.find_element(By.CSS_SELECTOR, CONSENT_SELECTOR)
     except NoSuchElementException:
-        return None
+        return False
 
 
 def _consent_checked(driver: WebDriver) -> bool:
     """Return True when the consent checkbox exists and is checked."""
     chk_box = _find_consent(driver)
-    return chk_box is not None and chk_box.is_selected()
+    return bool(chk_box and chk_box.is_selected())
 
 
-def _enabled_start_button(driver: WebDriver) -> WebElement | None:
+def _enabled_start_button(driver: WebDriver) -> WebElement | Literal[False]:
     """Return the start button once it no longer carries the disabled class."""
     try:
         btn = driver.find_element(By.CSS_SELECTOR, "a.startButton")
     except NoSuchElementException:
-        return None
+        return False
     if "disabled" in (btn.get_attribute("class") or ""):
-        return None
+        return False
     return btn
 
 

--- a/speedtest_z/sites/mlab.py
+++ b/speedtest_z/sites/mlab.py
@@ -3,19 +3,52 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
-from selenium.common.exceptions import TimeoutException
+from selenium.common.exceptions import NoSuchElementException, TimeoutException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 
 if TYPE_CHECKING:
+    from selenium.webdriver.remote.webdriver import WebDriver
+    from selenium.webdriver.remote.webelement import WebElement
+
     from speedtest_z.runner import SpeedtestZ
 
 logger = logging.getLogger("speedtest-z")
 
 URL = "https://speed.measurementlab.net/"
+
+# Data-policy consent checkbox: current site id first, legacy id as fallback
+CONSENT_IDS = ("privacyConsent", "demo-human")
+
+
+def _find_consent(driver: WebDriver) -> WebElement | None:
+    """Return the consent checkbox element, or None if not present."""
+    for consent_id in CONSENT_IDS:
+        try:
+            return driver.find_element(By.ID, consent_id)
+        except NoSuchElementException:
+            continue
+    return None
+
+
+def _consent_checked(driver: WebDriver) -> bool:
+    """Return True when the consent checkbox exists and is checked."""
+    chk_box = _find_consent(driver)
+    return chk_box is not None and chk_box.is_selected()
+
+
+def _enabled_start_button(driver: WebDriver) -> WebElement | Literal[False]:
+    """Return the start button once it no longer carries the disabled class."""
+    try:
+        btn = driver.find_element(By.CSS_SELECTOR, "a.startButton")
+    except NoSuchElementException:
+        return False
+    if "disabled" in (btn.get_attribute("class") or ""):
+        return False
+    return btn
 
 
 def run_mlab(app: SpeedtestZ) -> None:
@@ -30,7 +63,7 @@ def run_mlab(app: SpeedtestZ) -> None:
 
         if app.auto_consent:
             try:
-                chk_box = app.wait.until(EC.presence_of_element_located((By.ID, "demo-human")))
+                chk_box = app.wait.until(lambda d: _find_consent(d))
                 app.driver.execute_script("arguments[0].click();", chk_box)
                 logger.info("mlab: Consent checked (auto)")
             except TimeoutException:
@@ -38,23 +71,20 @@ def run_mlab(app: SpeedtestZ) -> None:
         else:
             # Wait for the user to click the checkbox
             try:
-                chk_box = WebDriverWait(app.driver, 5).until(
-                    EC.presence_of_element_located((By.ID, "demo-human"))
-                )
+                chk_box = WebDriverWait(app.driver, 5).until(lambda d: _find_consent(d))
                 if not chk_box.is_selected():
                     logger.info("mlab: Waiting for user to check consent checkbox...")
-                    WebDriverWait(app.driver, 120).until(
-                        lambda d: d.find_element(By.ID, "demo-human").is_selected()
-                    )
+                    WebDriverWait(app.driver, 120).until(_consent_checked)
                     logger.info("mlab: Consent checked by user")
             except TimeoutException:
                 logger.debug("mlab: Consent checkbox not found or not checked")
 
         try:
-            start_btn = app.wait.until(
-                EC.element_to_be_clickable((By.CSS_SELECTOR, "a.startButton"))
-            )
-            start_btn.click()
+            # The button keeps a "disabled" class until consent is given, and
+            # an overlay can intercept a native click, so wait for the class to
+            # clear and click via JavaScript.
+            start_btn = app.wait.until(_enabled_start_button)
+            app.driver.execute_script("arguments[0].click();", start_btn)
             logger.info("mlab: START")
         except Exception as e:
             logger.error(f"mlab: Start button issue: {e}")

--- a/speedtest_z/sites/ookla.py
+++ b/speedtest_z/sites/ookla.py
@@ -6,11 +6,7 @@ import logging
 import time
 from typing import TYPE_CHECKING
 
-from selenium.common.exceptions import (
-    NoSuchElementException,
-    StaleElementReferenceException,
-    TimeoutException,
-)
+from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
@@ -21,6 +17,39 @@ if TYPE_CHECKING:
 logger = logging.getLogger("speedtest-z")
 
 URL = "https://www.speedtest.net/"
+
+# The redesigned UI (React/MUI, observed 2026-07) has no stable ids/classes on
+# the GO button; the aria-label is the only semantic hook.
+START_BUTTON = (By.CSS_SELECTOR, 'button[aria-label^="start speed test"]')
+
+# Result values render as <h3 class="... font-mono ..."> inside a small
+# labelled container, and latency values as bare numeric spans. The utility
+# (Tailwind) class names carry no semantics, so extract everything in one
+# JavaScript pass. Each h3 is classified by its NEAREST labelled ancestor
+# ("Download Mbps 92.98" / "Upload Mbps 87.07"); a wider ancestor whose text
+# contains both labels is ambiguous and must be skipped, otherwise the
+# download value would also be reported as upload.
+_EXTRACT_RESULTS_JS = """
+const results = {download: null, upload: null};
+for (const h of document.querySelectorAll('h3.font-mono')) {
+  let box = h.parentElement;
+  for (let i = 0; i < 4 && box; i++) {
+    const t = (box.textContent || '').toLowerCase();
+    if (t.length < 60 && (t.includes('download') || t.includes('upload'))) {
+      if (!(t.includes('download') && t.includes('upload'))) {
+        const key = t.includes('download') ? 'download' : 'upload';
+        if (results[key] === null) results[key] = h.textContent.trim();
+      }
+      break;
+    }
+    box = box.parentElement;
+  }
+}
+const pings = [...document.querySelectorAll('span[class*="min-w"]')]
+  .map(e => (e.textContent || '').trim())
+  .filter(t => /^[0-9]+$/.test(t));
+return {download: results.download, upload: results.upload, ping: pings[0] || null};
+"""
 
 
 def run_ookla(app: SpeedtestZ) -> None:
@@ -33,8 +62,12 @@ def run_ookla(app: SpeedtestZ) -> None:
             logger.info(f"ookla: OPEN (Attempt {attempt + 1}/{app.MAX_RETRIES})")
 
             if attempt > 0:
+                # Navigate back to the top page: a finished attempt leaves the
+                # browser on a /result/<id> URL where refresh() would not
+                # offer a new test.
                 logger.info("ookla: Reloading page...")
-                app.driver.refresh()
+                if not app._load_with_retry(URL):
+                    return
                 time.sleep(5)
             else:
                 if not app._load_with_retry(URL):
@@ -61,7 +94,10 @@ def run_ookla(app: SpeedtestZ) -> None:
                 except TimeoutException:
                     logger.debug("ookla: Privacy banner not found or not dismissed")
 
-            # Server Selection
+            # Server Selection (best effort: written for the pre-2026 UI; the
+            # redesigned UI keeps a "Change Server" link but the surrounding
+            # selectors are unverified. Failures fall through to the default
+            # auto-selected server.)
             if app.ookla_server is not None:
                 need_change = True
                 try:
@@ -132,65 +168,36 @@ def run_ookla(app: SpeedtestZ) -> None:
                             logger.warning(f"ookla: Server selection failed: {e}")
 
             try:
-                start_btn = app.wait.until(
-                    EC.element_to_be_clickable((By.CLASS_NAME, "start-text"))
-                )
+                start_btn = app.wait.until(EC.element_to_be_clickable(START_BUTTON))
                 start_btn.click()
                 logger.info("ookla: START")
             except Exception as e:
                 logger.warning(f"ookla: Start button error: {e}")
                 continue
 
-            def _check_result_or_error(d):
-                try:
-                    try:
-                        if d.find_element(
-                            By.CSS_SELECTOR,
-                            ".error-container, .notification-error",
-                        ).is_displayed():
-                            return "ERROR"
-                    except NoSuchElementException:
-                        pass
-
-                    try:
-                        if d.find_element(By.CLASS_NAME, "result-data-large").is_displayed():
-                            dl = d.find_element(By.CLASS_NAME, "download-speed").text
-                            ul = d.find_element(By.CLASS_NAME, "upload-speed").text
-                            if (
-                                dl
-                                and ul
-                                and dl not in ["\u2014", "-"]
-                                and ul not in ["\u2014", "-"]
-                            ):
-                                return "SUCCESS"
-                    except NoSuchElementException:
-                        pass
-                except StaleElementReferenceException:
-                    pass
-                return False
-
+            # A finished test navigates to /result/<id>; an error popup or a
+            # stalled test never does, so the timeout below covers both.
             try:
-                status = WebDriverWait(app.driver, 90).until(_check_result_or_error)
+                WebDriverWait(app.driver, 90).until(lambda d: "/result/" in d.current_url)
             except TimeoutException:
                 logger.error("ookla: Timeout waiting for results.")
-                status = "TIMEOUT"
-
-            if status == "ERROR":
-                logger.warning("ookla: Detected Error Popup. Retrying...")
-                app.take_snapshot(f"ookla_error_{attempt + 1}")
-                continue
-            elif status == "TIMEOUT":
                 app.take_snapshot(f"ookla_timeout_{attempt + 1}")
                 continue
 
             logger.info("ookla: COMPLETED")
             time.sleep(2)
 
-            download = app.driver.find_element(By.CLASS_NAME, "download-speed").text
-            upload = app.driver.find_element(By.CLASS_NAME, "upload-speed").text
-            ping = app.driver.find_element(By.CLASS_NAME, "ping-speed").text
+            result = app.driver.execute_script(_EXTRACT_RESULTS_JS) or {}
+            download = result.get("download") or ""
+            upload = result.get("upload") or ""
+            ping = result.get("ping") or ""
 
             logger.debug(f"ookla Result: {download=} {upload=} {ping=}")
+
+            if not any(c.isdigit() for c in download):
+                logger.error("ookla: Invalid download value; skipping send.")
+                app.take_snapshot(f"ookla_error_parse_{attempt + 1}")
+                continue
 
             data = [
                 {

--- a/speedtest_z/sites/ookla.py
+++ b/speedtest_z/sites/ookla.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 import time
 from typing import TYPE_CHECKING
 
@@ -19,8 +20,9 @@ logger = logging.getLogger("speedtest-z")
 URL = "https://www.speedtest.net/"
 
 # The redesigned UI (React/MUI, observed 2026-07) has no stable ids/classes on
-# the GO button; the aria-label is the only semantic hook.
-START_BUTTON = (By.CSS_SELECTOR, 'button[aria-label^="start speed test"]')
+# the GO button; the aria-label is the only semantic hook. The trailing "i"
+# makes the match case-insensitive so a cosmetic case change cannot break it.
+START_BUTTON = (By.CSS_SELECTOR, 'button[aria-label^="start speed test" i]')
 
 # Result values render as <h3 class="... font-mono ..."> inside a small
 # labelled container, and latency values as bare numeric spans. The utility
@@ -45,11 +47,38 @@ for (const h of document.querySelectorAll('h3.font-mono')) {
     box = box.parentElement;
   }
 }
-const pings = [...document.querySelectorAll('span[class*="min-w"]')]
-  .map(e => (e.textContent || '').trim())
-  .filter(t => /^[0-9]+$/.test(t));
-return {download: results.download, upload: results.upload, ping: pings[0] || null};
+const isNum = (t) => /^[0-9]+(\\.[0-9]+)?$/.test(t);
+let ping = null;
+// The three latency rows each carry an icon labelled "Idle Latency" /
+// "Download Latency" / "Upload Latency"; anchor idle ping to its icon so a
+// layout reorder cannot swap in a different latency value.
+const idleIcon = document.querySelector('[aria-label="idle latency" i]');
+if (idleIcon && idleIcon.parentElement) {
+  const span = [...idleIcon.parentElement.querySelectorAll('span')]
+    .find(s => isNum((s.textContent || '').trim()));
+  if (span) ping = span.textContent.trim();
+}
+if (ping === null) {
+  const pings = [...document.querySelectorAll('span[class*="min-w"]')]
+    .map(e => (e.textContent || '').trim())
+    .filter(isNum);
+  ping = pings[0] || null;
+}
+return {download: results.download, upload: results.upload, ping: ping};
 """
+
+
+def _clean_number(text: str) -> str:
+    """Normalize a scraped value to a bare numeric string.
+
+    Strips thousands separators and unit suffixes ("1,053.9" -> "1053.9",
+    "92.98 Mbps" -> "92.98"); returns "" when no numeric token remains, so
+    callers can treat the value as a parse failure. Zabbix items are FLOAT
+    and would reject a comma- or unit-decorated string.
+    """
+    tokens = text.replace(",", "").split()
+    token = tokens[0] if tokens else ""
+    return token if re.fullmatch(r"[0-9]+(\.[0-9]+)?", token) else ""
 
 
 def run_ookla(app: SpeedtestZ) -> None:
@@ -61,17 +90,15 @@ def run_ookla(app: SpeedtestZ) -> None:
         try:
             logger.info(f"ookla: OPEN (Attempt {attempt + 1}/{app.MAX_RETRIES})")
 
+            # On retries, navigate back to the top page: a finished attempt
+            # leaves the browser on a /result/<id> URL where refresh() would
+            # not offer a new test.
             if attempt > 0:
-                # Navigate back to the top page: a finished attempt leaves the
-                # browser on a /result/<id> URL where refresh() would not
-                # offer a new test.
                 logger.info("ookla: Reloading page...")
-                if not app._load_with_retry(URL):
-                    return
+            if not app._load_with_retry(URL):
+                return
+            if attempt > 0:
                 time.sleep(5)
-            else:
-                if not app._load_with_retry(URL):
-                    return
 
             if app.auto_consent:
                 try:
@@ -188,14 +215,16 @@ def run_ookla(app: SpeedtestZ) -> None:
             time.sleep(2)
 
             result = app.driver.execute_script(_EXTRACT_RESULTS_JS) or {}
-            download = result.get("download") or ""
-            upload = result.get("upload") or ""
-            ping = result.get("ping") or ""
+            download = _clean_number(result.get("download") or "")
+            upload = _clean_number(result.get("upload") or "")
+            ping = _clean_number(result.get("ping") or "")
 
             logger.debug(f"ookla Result: {download=} {upload=} {ping=}")
 
-            if not any(c.isdigit() for c in download):
-                logger.error("ookla: Invalid download value; skipping send.")
+            # Both throughput values must parse, or the attempt is retried —
+            # sending a partial result would hide an extraction regression.
+            if not download or not upload:
+                logger.error("ookla: Invalid download/upload value; retrying.")
                 app.take_snapshot(f"ookla_error_parse_{attempt + 1}")
                 continue
 
@@ -210,12 +239,19 @@ def run_ookla(app: SpeedtestZ) -> None:
                     "key": "ookla.upload",
                     "value": upload,
                 },
-                {
-                    "host": app.zabbix_host,
-                    "key": "ookla.ping",
-                    "value": ping,
-                },
             ]
+            if ping:
+                data.append(
+                    {
+                        "host": app.zabbix_host,
+                        "key": "ookla.ping",
+                        "value": ping,
+                    }
+                )
+            else:
+                # The ping span heuristic is weaker than the labelled h3s;
+                # do not fail a good throughput measurement over it.
+                logger.warning("ookla: ping value missing; sending download/upload only.")
             app.send_results(data)
             app.take_snapshot("ookla")
             return

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -404,6 +404,43 @@ class TestMainFatalExit:
             mock_app.close.assert_called()  # finally still cleans up
 
 
+class TestMainKeyboardInterrupt:
+    """main() exits with 130 (128+SIGINT) when interrupted by Ctrl-C."""
+
+    def test_keyboard_interrupt_exits_130(self):
+        """A KeyboardInterrupt closes the app and exits with code 130."""
+
+        def _interrupt(app):
+            raise KeyboardInterrupt
+
+        with (
+            patch("speedtest_z.cli._build_parser") as mock_parser,
+            patch("speedtest_z.cli._setup_logging"),
+            patch("speedtest_z.cli._find_config", return_value="/tmp/config.ini"),
+            patch("speedtest_z.runner.SpeedtestZ") as mock_stz,
+            patch("speedtest_z.cli.get_site_runners", return_value={"cloudflare": _interrupt}),
+            patch("sys.stdin") as mock_stdin,
+        ):
+            mock_args = MagicMock()
+            mock_args.man = False
+            mock_args.list_sites = False
+            mock_args.check = False
+            mock_args.debug = False
+            mock_args.config = None
+            mock_args.output = "zabbix"
+            mock_args.yes = True
+            mock_args.sites = ["cloudflare"]
+            mock_parser.return_value.parse_args.return_value = mock_args
+            mock_app = MagicMock()
+            mock_stz.return_value = mock_app
+            mock_stdin.isatty.return_value = False
+
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            assert exc_info.value.code == 130
+            mock_app.close.assert_called()  # finally still cleans up
+
+
 class TestI18nMessages:
     """Tests for _msg() switching between Japanese and English."""
 

--- a/tests/test_sites/test_mlab.py
+++ b/tests/test_sites/test_mlab.py
@@ -1,10 +1,10 @@
 """Tests for the M-Lab site runner."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
-from selenium.common.exceptions import TimeoutException
+from selenium.common.exceptions import NoSuchElementException, TimeoutException
 
-from speedtest_z.sites.mlab import run_mlab
+from speedtest_z.sites.mlab import _enabled_start_button, _find_consent, run_mlab
 
 
 def _mock_find_element_results(
@@ -25,6 +25,54 @@ def _mock_find_element_results(
         return el
 
     return _find
+
+
+class TestMlabHelpers:
+    """Tests for the consent/start-button helpers."""
+
+    def test_find_consent_prefers_current_id(self):
+        """The current site id (privacyConsent) is tried first."""
+        driver = MagicMock()
+        el = MagicMock()
+        driver.find_element.return_value = el
+        assert _find_consent(driver) is el
+        assert driver.find_element.call_args[0][1] == "privacyConsent"
+
+    def test_find_consent_falls_back_to_legacy_id(self):
+        """The legacy id (demo-human) is used when the current one is absent."""
+        driver = MagicMock()
+        el = MagicMock()
+        driver.find_element.side_effect = [NoSuchElementException(), el]
+        assert _find_consent(driver) is el
+        assert driver.find_element.call_args[0][1] == "demo-human"
+
+    def test_find_consent_returns_none_when_absent(self):
+        """None is returned when no consent checkbox exists."""
+        driver = MagicMock()
+        driver.find_element.side_effect = NoSuchElementException()
+        assert _find_consent(driver) is None
+
+    def test_enabled_start_button_waits_out_disabled_class(self):
+        """False is returned while the button still has the disabled class."""
+        driver = MagicMock()
+        btn = MagicMock()
+        btn.get_attribute.return_value = "button special startButton big disabled"
+        driver.find_element.return_value = btn
+        assert _enabled_start_button(driver) is False
+
+    def test_enabled_start_button_returns_button(self):
+        """The button is returned once the disabled class is gone."""
+        driver = MagicMock()
+        btn = MagicMock()
+        btn.get_attribute.return_value = "button special startButton big"
+        driver.find_element.return_value = btn
+        assert _enabled_start_button(driver) is btn
+
+    def test_enabled_start_button_absent(self):
+        """False is returned when the button does not exist yet."""
+        driver = MagicMock()
+        driver.find_element.side_effect = NoSuchElementException()
+        assert _enabled_start_button(driver) is False
 
 
 class TestRunMlab:
@@ -114,7 +162,11 @@ class TestRunMlab:
             mock_wdw.return_value.until.return_value = True
             run_mlab(mock_app)
 
-        mock_app.driver.execute_script.assert_called_once()
+        # Both the consent checkbox and the start button are clicked via JS
+        assert mock_app.driver.execute_script.call_count == 2
+        assert mock_app.driver.execute_script.call_args_list[0] == call(
+            "arguments[0].click();", chk_box
+        )
 
     def test_start_button_error_returns_early(self, mock_app):
         """Return early when start button is not clickable."""

--- a/tests/test_sites/test_mlab.py
+++ b/tests/test_sites/test_mlab.py
@@ -4,7 +4,12 @@ from unittest.mock import MagicMock, call, patch
 
 from selenium.common.exceptions import NoSuchElementException, TimeoutException
 
-from speedtest_z.sites.mlab import _enabled_start_button, _find_consent, run_mlab
+from speedtest_z.sites.mlab import (
+    CONSENT_SELECTOR,
+    _enabled_start_button,
+    _find_consent,
+    run_mlab,
+)
 
 
 def _mock_find_element_results(
@@ -30,21 +35,18 @@ def _mock_find_element_results(
 class TestMlabHelpers:
     """Tests for the consent/start-button helpers."""
 
-    def test_find_consent_prefers_current_id(self):
-        """The current site id (privacyConsent) is tried first."""
+    def test_consent_selector_covers_current_and_legacy_ids(self):
+        """The combined selector matches both the current and legacy ids."""
+        assert "#privacyConsent" in CONSENT_SELECTOR
+        assert "#demo-human" in CONSENT_SELECTOR
+
+    def test_find_consent_returns_element(self):
+        """The consent checkbox element is returned when present."""
         driver = MagicMock()
         el = MagicMock()
         driver.find_element.return_value = el
         assert _find_consent(driver) is el
-        assert driver.find_element.call_args[0][1] == "privacyConsent"
-
-    def test_find_consent_falls_back_to_legacy_id(self):
-        """The legacy id (demo-human) is used when the current one is absent."""
-        driver = MagicMock()
-        el = MagicMock()
-        driver.find_element.side_effect = [NoSuchElementException(), el]
-        assert _find_consent(driver) is el
-        assert driver.find_element.call_args[0][1] == "demo-human"
+        assert driver.find_element.call_args[0][1] == CONSENT_SELECTOR
 
     def test_find_consent_returns_none_when_absent(self):
         """None is returned when no consent checkbox exists."""
@@ -53,12 +55,12 @@ class TestMlabHelpers:
         assert _find_consent(driver) is None
 
     def test_enabled_start_button_waits_out_disabled_class(self):
-        """False is returned while the button still has the disabled class."""
+        """None is returned while the button still has the disabled class."""
         driver = MagicMock()
         btn = MagicMock()
         btn.get_attribute.return_value = "button special startButton big disabled"
         driver.find_element.return_value = btn
-        assert _enabled_start_button(driver) is False
+        assert _enabled_start_button(driver) is None
 
     def test_enabled_start_button_returns_button(self):
         """The button is returned once the disabled class is gone."""
@@ -69,10 +71,10 @@ class TestMlabHelpers:
         assert _enabled_start_button(driver) is btn
 
     def test_enabled_start_button_absent(self):
-        """False is returned when the button does not exist yet."""
+        """None is returned when the button does not exist yet."""
         driver = MagicMock()
         driver.find_element.side_effect = NoSuchElementException()
-        assert _enabled_start_button(driver) is False
+        assert _enabled_start_button(driver) is None
 
 
 class TestRunMlab:
@@ -154,6 +156,7 @@ class TestRunMlab:
         mock_app.driver.find_element.side_effect = _mock_find_element_results()
 
         chk_box = MagicMock()
+        chk_box.is_selected.return_value = False
         with patch("speedtest_z.sites.mlab.WebDriverWait") as mock_wdw:
             mock_app.wait.until.side_effect = [
                 chk_box,  # consent checkbox
@@ -167,6 +170,30 @@ class TestRunMlab:
         assert mock_app.driver.execute_script.call_args_list[0] == call(
             "arguments[0].click();", chk_box
         )
+
+    def test_auto_consent_prechecked_not_clicked(self, mock_app):
+        """A pre-checked consent checkbox must not be toggled off."""
+        mock_app._should_run = MagicMock(return_value=True)
+        mock_app._load_with_retry = MagicMock(return_value=True)
+        mock_app.auto_consent = True
+        mock_app.send_results = MagicMock()
+        mock_app.take_snapshot = MagicMock()
+        mock_app.driver.find_element.side_effect = _mock_find_element_results()
+
+        chk_box = MagicMock()
+        chk_box.is_selected.return_value = True
+        with patch("speedtest_z.sites.mlab.WebDriverWait") as mock_wdw:
+            mock_app.wait.until.side_effect = [
+                chk_box,  # consent checkbox (already checked)
+                MagicMock(),  # start button
+            ]
+            mock_wdw.return_value.until.return_value = True
+            run_mlab(mock_app)
+
+        # Only the start button is JS-clicked; the checkbox is left alone
+        assert mock_app.driver.execute_script.call_count == 1
+        for js_call in mock_app.driver.execute_script.call_args_list:
+            assert js_call[0][1] is not chk_box
 
     def test_start_button_error_returns_early(self, mock_app):
         """Return early when start button is not clickable."""

--- a/tests/test_sites/test_mlab.py
+++ b/tests/test_sites/test_mlab.py
@@ -48,19 +48,19 @@ class TestMlabHelpers:
         assert _find_consent(driver) is el
         assert driver.find_element.call_args[0][1] == CONSENT_SELECTOR
 
-    def test_find_consent_returns_none_when_absent(self):
-        """None is returned when no consent checkbox exists."""
+    def test_find_consent_returns_false_when_absent(self):
+        """False is returned when no consent checkbox exists."""
         driver = MagicMock()
         driver.find_element.side_effect = NoSuchElementException()
-        assert _find_consent(driver) is None
+        assert _find_consent(driver) is False
 
     def test_enabled_start_button_waits_out_disabled_class(self):
-        """None is returned while the button still has the disabled class."""
+        """False is returned while the button still has the disabled class."""
         driver = MagicMock()
         btn = MagicMock()
         btn.get_attribute.return_value = "button special startButton big disabled"
         driver.find_element.return_value = btn
-        assert _enabled_start_button(driver) is None
+        assert _enabled_start_button(driver) is False
 
     def test_enabled_start_button_returns_button(self):
         """The button is returned once the disabled class is gone."""
@@ -71,10 +71,10 @@ class TestMlabHelpers:
         assert _enabled_start_button(driver) is btn
 
     def test_enabled_start_button_absent(self):
-        """None is returned when the button does not exist yet."""
+        """False is returned when the button does not exist yet."""
         driver = MagicMock()
         driver.find_element.side_effect = NoSuchElementException()
-        assert _enabled_start_button(driver) is None
+        assert _enabled_start_button(driver) is False
 
 
 class TestRunMlab:

--- a/tests/test_sites/test_ookla.py
+++ b/tests/test_sites/test_ookla.py
@@ -2,32 +2,14 @@
 
 from unittest.mock import MagicMock, patch
 
-from selenium.common.exceptions import (
-    NoSuchElementException,
-    TimeoutException,
-)
+from selenium.common.exceptions import TimeoutException
 
 from speedtest_z.sites.ookla import run_ookla
 
 
-def _mock_find_element_results(download="250.5", upload="80.3", ping="5"):
-    """Return a side_effect function for find_element returning result texts."""
-    results = {
-        "download-speed": download,
-        "upload-speed": upload,
-        "ping-speed": ping,
-        "result-data-large": "visible",
-    }
-
-    def _find(by, class_name):
-        if class_name in results:
-            el = MagicMock()
-            el.text = results[class_name]
-            el.is_displayed.return_value = True
-            return el
-        raise NoSuchElementException(f"Element {class_name} not found")
-
-    return _find
+def _result(download="250.5", upload="80.3", ping="5"):
+    """Return a result dict as produced by the extraction JavaScript."""
+    return {"download": download, "upload": upload, "ping": ping}
 
 
 class TestRunOokla:
@@ -57,7 +39,7 @@ class TestRunOokla:
         mock_app.send_results = MagicMock()
         mock_app.take_snapshot = MagicMock()
         mock_app.MAX_RETRIES = 3
-        mock_app.driver.find_element.side_effect = _mock_find_element_results("300.0", "95.5", "3")
+        mock_app.driver.execute_script.return_value = _result("300.0", "95.5", "3")
 
         with (
             patch("speedtest_z.sites.ookla.WebDriverWait") as mock_wdw,
@@ -65,7 +47,7 @@ class TestRunOokla:
         ):
             mock_wdw.return_value.until.side_effect = [
                 TimeoutException(),  # consent dialog not found
-                "SUCCESS",  # _check_result_or_error
+                True,  # completion (URL changed to /result/<id>)
             ]
             mock_app.wait.until.return_value = MagicMock()  # start button
             run_ookla(mock_app)
@@ -81,7 +63,7 @@ class TestRunOokla:
         assert data[2]["value"] == "3"
 
     def test_start_button_error_retries(self, mock_app):
-        """Retry when start button click fails."""
+        """Retry when start button click fails, reloading the top page."""
         mock_app._should_run = MagicMock(return_value=True)
         mock_app._load_with_retry = MagicMock(return_value=True)
         mock_app.auto_consent = True
@@ -100,9 +82,11 @@ class TestRunOokla:
             run_ookla(mock_app)
 
         mock_app.send_results.assert_not_called()
+        # Each attempt loads the top page (refresh would stay on /result/<id>)
+        assert mock_app._load_with_retry.call_count == 2
 
-    def test_error_popup_triggers_retry(self, mock_app):
-        """Retry when error popup is detected."""
+    def test_invalid_result_triggers_retry(self, mock_app):
+        """Retry when the result page yields no numeric download value."""
         mock_app._should_run = MagicMock(return_value=True)
         mock_app._load_with_retry = MagicMock(return_value=True)
         mock_app.auto_consent = True
@@ -110,19 +94,10 @@ class TestRunOokla:
         mock_app.send_results = MagicMock()
         mock_app.take_snapshot = MagicMock()
         mock_app.MAX_RETRIES = 2
-
-        call_count = [0]
-
-        def _mock_find(by, selector):
-            call_count[0] += 1
-            el = MagicMock()
-            el.text = "300.0" if "download" in selector else "95.5"
-            if "ping" in selector:
-                el.text = "3"
-            el.is_displayed.return_value = True
-            return el
-
-        mock_app.driver.find_element.side_effect = _mock_find
+        mock_app.driver.execute_script.side_effect = [
+            _result(download="", upload="", ping=""),  # 1st attempt: parse failure
+            _result("300.0", "95.5", "3"),  # 2nd attempt: success
+        ]
 
         with (
             patch("speedtest_z.sites.ookla.WebDriverWait") as mock_wdw,
@@ -130,18 +105,18 @@ class TestRunOokla:
         ):
             mock_wdw.return_value.until.side_effect = [
                 TimeoutException(),  # consent 1st attempt
-                "ERROR",  # 1st attempt result check
+                True,  # completion 1st attempt
                 TimeoutException(),  # consent 2nd attempt
-                "SUCCESS",  # 2nd attempt result check
+                True,  # completion 2nd attempt
             ]
             mock_app.wait.until.return_value = MagicMock()  # start button
             run_ookla(mock_app)
 
         mock_app.send_results.assert_called_once()
-        mock_app.take_snapshot.assert_any_call("ookla_error_1")
+        mock_app.take_snapshot.assert_any_call("ookla_error_parse_1")
 
     def test_timeout_triggers_retry(self, mock_app):
-        """Retry when timeout occurs waiting for results."""
+        """Retry when timeout occurs waiting for the result URL."""
         mock_app._should_run = MagicMock(return_value=True)
         mock_app._load_with_retry = MagicMock(return_value=True)
         mock_app.auto_consent = True
@@ -156,9 +131,9 @@ class TestRunOokla:
         ):
             mock_wdw.return_value.until.side_effect = [
                 TimeoutException(),  # consent 1st
-                TimeoutException(),  # results timeout 1st
+                TimeoutException(),  # completion timeout 1st
                 TimeoutException(),  # consent 2nd
-                TimeoutException(),  # results timeout 2nd
+                TimeoutException(),  # completion timeout 2nd
             ]
             mock_app.wait.until.return_value = MagicMock()
             run_ookla(mock_app)
@@ -183,7 +158,7 @@ class TestRunOokla:
         ):
             mock_wdw.return_value.until.side_effect = [
                 TimeoutException(),  # consent
-                "ERROR",  # error popup
+                TimeoutException(),  # completion timeout
             ]
             mock_app.wait.until.return_value = MagicMock()
             run_ookla(mock_app)
@@ -199,7 +174,10 @@ class TestRunOokla:
         mock_app.send_results = MagicMock()
         mock_app.take_snapshot = MagicMock()
         mock_app.MAX_RETRIES = 1
-        mock_app.driver.find_element.side_effect = _mock_find_element_results()
+        mock_app.driver.execute_script.side_effect = [
+            None,  # consent click
+            _result(),  # result extraction
+        ]
 
         consent_btn = MagicMock()
         with (
@@ -208,14 +186,14 @@ class TestRunOokla:
         ):
             mock_wdw.return_value.until.side_effect = [
                 consent_btn,  # consent dialog found
-                "SUCCESS",  # results
+                True,  # completion
             ]
             mock_app.wait.until.return_value = MagicMock()
             run_ookla(mock_app)
 
-        mock_app.driver.execute_script.assert_called_once_with(
-            "arguments[0].click();", consent_btn
-        )
+        first_call = mock_app.driver.execute_script.call_args_list[0]
+        assert first_call[0] == ("arguments[0].click();", consent_btn)
+        mock_app.send_results.assert_called_once()
 
     def test_manual_consent_mode(self, mock_app):
         """In manual consent mode, wait for user to dismiss banner."""
@@ -226,7 +204,7 @@ class TestRunOokla:
         mock_app.send_results = MagicMock()
         mock_app.take_snapshot = MagicMock()
         mock_app.MAX_RETRIES = 1
-        mock_app.driver.find_element.side_effect = _mock_find_element_results()
+        mock_app.driver.execute_script.return_value = _result()
 
         banner = MagicMock()
         with (
@@ -236,7 +214,7 @@ class TestRunOokla:
             mock_wdw.return_value.until.side_effect = [
                 banner,  # banner visible
                 True,  # banner dismissed
-                "SUCCESS",  # results
+                True,  # completion
             ]
             mock_app.wait.until.return_value = MagicMock()
             run_ookla(mock_app)
@@ -252,7 +230,7 @@ class TestRunOokla:
         mock_app.send_results = MagicMock()
         mock_app.take_snapshot = MagicMock()
         mock_app.MAX_RETRIES = 1
-        mock_app.driver.find_element.side_effect = _mock_find_element_results()
+        mock_app.driver.execute_script.return_value = _result()
 
         server_elem = MagicMock()
         server_elem.text = "CurrentServer"  # different from ookla_server
@@ -268,7 +246,7 @@ class TestRunOokla:
             mock_wdw.return_value.until.side_effect = [
                 TimeoutException(),  # consent
                 server_elem,  # current server element
-                "SUCCESS",  # results
+                True,  # completion
             ]
             mock_app.wait.until.side_effect = [
                 change_link,  # Change Server link
@@ -291,7 +269,7 @@ class TestRunOokla:
         mock_app.take_snapshot = MagicMock()
         mock_app.MAX_RETRIES = 1
         mock_app.zabbix_host = "my-host"
-        mock_app.driver.find_element.side_effect = _mock_find_element_results()
+        mock_app.driver.execute_script.return_value = _result()
 
         with (
             patch("speedtest_z.sites.ookla.WebDriverWait") as mock_wdw,
@@ -299,7 +277,7 @@ class TestRunOokla:
         ):
             mock_wdw.return_value.until.side_effect = [
                 TimeoutException(),
-                "SUCCESS",
+                True,
             ]
             mock_app.wait.until.return_value = MagicMock()
             run_ookla(mock_app)

--- a/tests/test_sites/test_ookla.py
+++ b/tests/test_sites/test_ookla.py
@@ -4,12 +4,31 @@ from unittest.mock import MagicMock, patch
 
 from selenium.common.exceptions import TimeoutException
 
-from speedtest_z.sites.ookla import run_ookla
+from speedtest_z.sites.ookla import _clean_number, run_ookla
 
 
 def _result(download="250.5", upload="80.3", ping="5"):
     """Return a result dict as produced by the extraction JavaScript."""
     return {"download": download, "upload": upload, "ping": ping}
+
+
+class TestCleanNumber:
+    """Tests for _clean_number()."""
+
+    def test_plain_number_passes_through(self):
+        assert _clean_number("92.98") == "92.98"
+        assert _clean_number("17") == "17"
+
+    def test_thousands_separator_stripped(self):
+        assert _clean_number("1,053.9") == "1053.9"
+
+    def test_unit_suffix_stripped(self):
+        assert _clean_number("92.98 Mbps") == "92.98"
+
+    def test_non_numeric_rejected(self):
+        assert _clean_number("") == ""
+        assert _clean_number("—") == ""
+        assert _clean_number("Mbps") == ""
 
 
 class TestRunOokla:
@@ -84,6 +103,52 @@ class TestRunOokla:
         mock_app.send_results.assert_not_called()
         # Each attempt loads the top page (refresh would stay on /result/<id>)
         assert mock_app._load_with_retry.call_count == 2
+
+    def test_comma_separated_values_normalized(self, mock_app):
+        """Thousands separators are stripped before sending to Zabbix."""
+        mock_app._should_run = MagicMock(return_value=True)
+        mock_app._load_with_retry = MagicMock(return_value=True)
+        mock_app.auto_consent = True
+        mock_app.ookla_server = None
+        mock_app.send_results = MagicMock()
+        mock_app.take_snapshot = MagicMock()
+        mock_app.MAX_RETRIES = 1
+        mock_app.driver.execute_script.return_value = _result("1,053.9", "1,002.1", "8.4")
+
+        with (
+            patch("speedtest_z.sites.ookla.WebDriverWait") as mock_wdw,
+            patch("speedtest_z.sites.ookla.time"),
+        ):
+            mock_wdw.return_value.until.side_effect = [TimeoutException(), True]
+            mock_app.wait.until.return_value = MagicMock()
+            run_ookla(mock_app)
+
+        data = mock_app.send_results.call_args[0][0]
+        assert data[0]["value"] == "1053.9"
+        assert data[1]["value"] == "1002.1"
+        assert data[2]["value"] == "8.4"
+
+    def test_missing_ping_sends_throughput_only(self, mock_app):
+        """A missing ping does not fail the run; download/upload still send."""
+        mock_app._should_run = MagicMock(return_value=True)
+        mock_app._load_with_retry = MagicMock(return_value=True)
+        mock_app.auto_consent = True
+        mock_app.ookla_server = None
+        mock_app.send_results = MagicMock()
+        mock_app.take_snapshot = MagicMock()
+        mock_app.MAX_RETRIES = 1
+        mock_app.driver.execute_script.return_value = _result("300.0", "95.5", None)
+
+        with (
+            patch("speedtest_z.sites.ookla.WebDriverWait") as mock_wdw,
+            patch("speedtest_z.sites.ookla.time"),
+        ):
+            mock_wdw.return_value.until.side_effect = [TimeoutException(), True]
+            mock_app.wait.until.return_value = MagicMock()
+            run_ookla(mock_app)
+
+        data = mock_app.send_results.call_args[0][0]
+        assert [d["key"] for d in data] == ["ookla.download", "ookla.upload"]
 
     def test_invalid_result_triggers_retry(self, mock_app):
         """Retry when the result page yields no numeric download value."""


### PR DESCRIPTION
## Summary

Fixes the two site runners that stopped working after upstream UI changes, and cleans up Ctrl-C behavior.

### ookla (speedtest.net redesign, React/MUI)
- The old `start-text` / `result-data-large` / `download-speed` classes no longer exist.
- Start: locate the GO button via `button[aria-label^="start speed test"]` (the only semantic hook left).
- Completion: a finished test navigates to `/result/<id>`, so wait on the URL instead of DOM classes. This also covers the old error-popup path (a stalled test never navigates and hits the retry timeout).
- Results: Tailwind utility classes carry no semantics, so extract download/upload/ping in one JavaScript pass. Each `h3.font-mono` value is classified by its nearest labelled ancestor; an ancestor containing both "Download" and "Upload" is skipped as ambiguous (first attempt reported download==upload because of this).
- Retries reload the top page (`refresh()` on a result URL does not offer a new test).

### mlab (speed.measurementlab.net)
- The data-policy consent checkbox id changed `demo-human` → `privacyConsent`; the legacy id is kept as a fallback.
- The start button keeps a `disabled` class until consent is given and an overlay intercepts native clicks, so wait for the class to clear and click via JavaScript.

### Ctrl-C cleanup
- `cli.main()` now exits with 130 (128+SIGINT) and skips the misleading `FINISH` log line.
- `take_snapshot()` failures log a one-line WARNING (full detail at DEBUG); previously a driver killed by Ctrl-C dumped a multi-line urllib3 stack into the log.

## Testing

- `ruff format --check` / `ruff check` / `mypy`: clean
- `pytest`: 329 passed (test_ookla rewritten for the new flow, mlab helper tests and a KeyboardInterrupt exit-code test added)
- Live verification (`speedtest-z --dry-run -y ookla mlab`):
  - ookla: `download=91.04 upload=78.25 ping=20`
  - mlab: `download=90.93 upload=92.43 latency=9 retrans=3.80` (consent auto-checked)

## Notes

- The ookla server-selection flow (`ookla_server` config, unset in production) still uses pre-redesign selectors; it fails soft to the auto-selected server. Left as-is, flagged in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSZ4DStF9gZzjfbcyT7pmX