### PR TITLE
fix: make -y/--yes skip the execution confirmation prompt

### DIFF
--- a/speedtest_z/cli.py
+++ b/speedtest_z/cli.py
@@ -139,11 +139,11 @@ def _init_logging(args: argparse.Namespace) -> None:
 def _confirm_execution(args: argparse.Namespace, sites: list[str]) -> bool:
     """Show confirmation prompt on TTY and return True to continue.
 
-    The prompt is always shown on TTY regardless of the --yes flag.
-    Returns True if the user confirms or stdin is not a TTY.
-    Returns False if the user declines.
+    Returns True without prompting when stdin is not a TTY (pipe/cron) or
+    when --yes was given (-y answers every prompt, matching the usual CLI
+    convention). Otherwise prompts and returns False if the user declines.
     """
-    if not sys.stdin.isatty():
+    if not sys.stdin.isatty() or getattr(args, "yes", False):
         return True
 
     site_list = ", ".join(sites)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -291,8 +291,8 @@ class TestMainConfirmPrompt:
             main()
             mock_stz.assert_called_once()
 
-    def test_prompt_shown_with_yes_flag(self):
-        """The confirmation prompt is still shown on a TTY even with --yes."""
+    def test_prompt_skipped_with_yes_flag(self):
+        """--yes skips the confirmation prompt even on a TTY."""
         with (
             patch("speedtest_z.cli._build_parser") as mock_parser,
             patch("speedtest_z.cli._setup_logging"),
@@ -300,7 +300,7 @@ class TestMainConfirmPrompt:
             patch("speedtest_z.runner.SpeedtestZ") as mock_stz,
             patch("speedtest_z.cli.get_site_runners", return_value={}),
             patch("sys.stdin") as mock_stdin,
-            patch("builtins.input", return_value="y") as mock_input,
+            patch("builtins.input") as mock_input,
         ):
             mock_args = self._make_args(yes=True)
             mock_parser.return_value.parse_args.return_value = mock_args
@@ -308,7 +308,7 @@ class TestMainConfirmPrompt:
             mock_app = MagicMock()
             mock_stz.return_value = mock_app
             main()
-            mock_input.assert_called_once()
+            mock_input.assert_not_called()
             mock_stz.assert_called_once()
 
     def test_prompt_skipped_on_non_tty(self):


### PR DESCRIPTION
## Summary

`-y/--yes` only auto-accepted the measurement sites' consent dialogs (OneTrust banner, M-Lab data-policy checkbox); the "Connect to 8 sites — continue?" TTY prompt was deliberately always shown (docstring: "always shown on TTY regardless of the --yes flag"). That contradicts the usual CLI convention where `-y` answers every prompt, and surprised users running `speedtest-z --dry-run --yes` interactively.

`_confirm_execution()` now returns early when `--yes` is given, so the flag answers every prompt. Non-TTY behavior (pipe/cron/systemd) is unchanged.

## Testing

- `ruff` clean, `pytest` 336 passed (rewrote `test_prompt_shown_with_yes_flag` → `test_prompt_skipped_with_yes_flag`)
- Live check on a pseudo-TTY (`script -q /dev/null`): `speedtest-z --dry-run --yes cloudflare` starts immediately without the prompt; without `--yes` the prompt still appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSZ4DStF9gZzjfbcyT7pmX