### PR TITLE
fix: exit 143 on SIGTERM and declare interrupt codes in systemd units

### DIFF
--- a/debian/speedtest-z.service
+++ b/debian/speedtest-z.service
@@ -7,6 +7,8 @@ Wants=network-online.target
 Type=simple
 EnvironmentFile=-/etc/default/speedtest-z
 ExecStart=/usr/bin/speedtest-z $SPEEDTEST_Z_OPTS
+# Interrupted runs exit 130 (SIGINT) / 143 (SIGTERM); treat both as clean stops
+SuccessExitStatus=130 143
 WorkingDirectory=/var/lib/speedtest-z
 User=speedtest-z
 Group=speedtest-z

--- a/deploy/speedtest-z.service
+++ b/deploy/speedtest-z.service
@@ -4,8 +4,10 @@ Description=speedtest-z service
 [Service]
 Type=simple
 EnvironmentFile=-/etc/default/speedtest-z
-# パスは環境に合わせて変更してください
+# Adjust the path to your environment
 ExecStart=/home/speedtest-z/.local/bin/speedtest-z $SPEEDTEST_Z_OPTS
+# Interrupted runs exit 130 (SIGINT) / 143 (SIGTERM); treat both as clean stops
+SuccessExitStatus=130 143
 WorkingDirectory=/home/speedtest-z
 User=speedtest-z
 Group=speedtest-z

--- a/speedtest_z/runner.py
+++ b/speedtest_z/runner.py
@@ -106,7 +106,10 @@ class SpeedtestZ:
         """Handle SIGTERM signal for graceful shutdown."""
         logger.info("SIGTERM received, shutting down...")
         self.close()
-        sys.exit(0)
+        # 128 + SIGTERM, mirroring the 130 (128+SIGINT) exit in cli.main() —
+        # an interrupted run must not report success (exit 0). The shipped
+        # systemd units list both codes in SuccessExitStatus.
+        sys.exit(143)
 
     def _init_driver(self) -> None:
         """Initialize Chrome WebDriver."""

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -4,6 +4,8 @@ import argparse
 import configparser
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from speedtest_z.runner import SpeedtestZ
 from speedtest_z.sender import SenderManager
 
@@ -481,6 +483,21 @@ class TestClose:
         app.driver.quit.side_effect = Exception("session already closed")
         app.close()  # should not raise
         app.sender.close.assert_called_once()
+
+
+class TestHandleSigterm:
+    """Tests for the SIGTERM handler."""
+
+    def test_sigterm_closes_and_exits_143(self):
+        """SIGTERM closes the app and exits with 143 (128+SIGTERM)."""
+        import signal as signal_mod
+
+        app = _make_app()
+        app.close = MagicMock()
+        with pytest.raises(SystemExit) as exc_info:
+            app._handle_sigterm(signal_mod.SIGTERM, None)
+        assert exc_info.value.code == 143
+        app.close.assert_called_once()
 
 
 class TestSenderManagerClose:


### PR DESCRIPTION
## Summary

Closes #40 (follow-up from the #38 review).

- `SpeedtestZ._handle_sigterm` exited 0, so `systemctl stop` mid-measurement reported success — the opposite of the exit-130 (128+SIGINT) semantics introduced in #38. It now exits 143 (128+SIGTERM).
- Both shipped systemd units (`deploy/`, `debian/`) declare `SuccessExitStatus=130 143` so an interrupted run counts as a clean stop, not a unit failure. Without this, exiting 143 from the handler would flip a `systemctl stop` into a failed state (an uncaught-signal death is clean by default, but a caught-and-exit is judged by exit code).
- Drive-by: the one remaining Japanese comment in `deploy/speedtest-z.service` is translated to English (deployed system files are ASCII-English-only by repo convention).

## Testing

- `ruff` clean, `pytest` 337 passed (new test: SIGTERM handler closes the app and raises SystemExit(143))

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSZ4DStF9gZzjfbcyT7pmX