### PR TITLE
fix: rewrite ookla server selection for the redesigned UI

### DIFF
--- a/config.ini-sample
+++ b/config.ini-sample
@@ -4,7 +4,10 @@ dry_run = true
 headless = false
 # Timeout in seconds
 timeout = 30
-# Ookla test server (omit for auto-select)
+# Ookla test server (omit for auto-select). Best effort: on the redesigned
+# speedtest.net the server picker only renders after server discovery
+# resolves, which has been observed to stall under automated (Selenium)
+# Chrome — the runner then falls back to the auto-selected server.
 # ookla_server = IPA CyberLab 400G
 # Chrome profile directory (for persisting cookies and consent)
 # chrome_profile_dir = ~/.config/speedtest-z/chrome-profile

--- a/speedtest_z/sites/ookla.py
+++ b/speedtest_z/sites/ookla.py
@@ -2,17 +2,22 @@
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import re
 import time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 
 if TYPE_CHECKING:
+    from selenium.webdriver.remote.webdriver import WebDriver
+    from selenium.webdriver.remote.webelement import WebElement
+
     from speedtest_z.runner import SpeedtestZ
 
 logger = logging.getLogger("speedtest-z")
@@ -81,6 +86,70 @@ def _clean_number(text: str) -> str:
     return token if re.fullmatch(r"[0-9]+(\.[0-9]+)?", token) else ""
 
 
+def _select_server(app: SpeedtestZ) -> None:
+    """Pin the measurement server on the redesigned UI (best effort).
+
+    Flow verified in a human-driven browser 2026-07-18: the pre-test page has
+    a "Change Server" <button> (the pre-2026 LINK_TEXT selector matched only
+    <a> tags), which opens a [role="dialog"] with a single text input; result
+    rows are div[role="button"] list items and the dialog closes on
+    selection. Caveat: under automated (Selenium) Chrome the pre-test server
+    discovery has been observed to stall ("Finding optimal server..."), in
+    which case the button never renders and this helper times out after 15s.
+    Any failure falls through to the auto-selected server.
+    """
+    server = app.ookla_server
+    if not server:
+        return
+
+    def _visible_change_button(driver: WebDriver) -> WebElement | Literal[False]:
+        # The page renders two "Change Server" buttons (responsive variants);
+        # element_to_be_clickable would latch onto the first match even when
+        # it is the hidden one, so pick whichever is actually displayed.
+        for btn in driver.find_elements(By.XPATH, "//button[normalize-space()='Change Server']"):
+            if btn.is_displayed() and btn.is_enabled():
+                return btn
+        return False
+
+    try:
+        # The button appears only after "Finding optimal server..." resolves
+        change_btn = WebDriverWait(app.driver, 15).until(_visible_change_button)
+        change_btn.click()
+        dialog = WebDriverWait(app.driver, 5).until(
+            EC.visibility_of_element_located((By.CSS_SELECTOR, '[role="dialog"]'))
+        )
+
+        # The dialog header shows the currently selected server
+        if server.lower() in dialog.text[:150].lower():
+            logger.info(f"ookla: Server already selected ({server}).")
+            app.driver.switch_to.active_element.send_keys(Keys.ESCAPE)
+            return
+
+        search_box = dialog.find_element(By.CSS_SELECTOR, 'input[type="text"]')
+        search_box.send_keys(server)
+
+        def _server_rows(driver: WebDriver) -> list[WebElement] | Literal[False]:
+            # Rows are div[role=button] list items; icon-only buttons (close,
+            # Select Automatically) are <button> tags or have no text
+            rows = [
+                r
+                for r in dialog.find_elements(By.CSS_SELECTOR, 'div[role="button"]')
+                if (r.text or "").strip()
+            ]
+            return rows or False
+
+        rows = WebDriverWait(app.driver, 10).until(_server_rows)
+        target = next((r for r in rows if server.lower() in r.text.lower()), rows[0])
+        label = target.text.splitlines()[0] if target.text else server
+        target.click()
+        logger.info(f"ookla: Server selected ({label})")
+    except Exception as e:
+        logger.warning(f"ookla: Server selection failed; using auto-selected server: {e}")
+        # Close a possibly-open dialog so it cannot block the GO button
+        with contextlib.suppress(Exception):
+            app.driver.switch_to.active_element.send_keys(Keys.ESCAPE)
+
+
 def run_ookla(app: SpeedtestZ) -> None:
     """Run Ookla Speedtest (speedtest.net)."""
     if not app._should_run("ookla"):
@@ -92,7 +161,9 @@ def run_ookla(app: SpeedtestZ) -> None:
 
             # On retries, navigate back to the top page: a finished attempt
             # leaves the browser on a /result/<id> URL where refresh() would
-            # not offer a new test.
+            # not offer a new test. A sustained reload failure (after
+            # _load_with_retry's own retries) aborts the runner instead of
+            # burning the remaining attempts on an unreachable page (#41).
             if attempt > 0:
                 logger.info("ookla: Reloading page...")
             if not app._load_with_retry(URL):
@@ -121,78 +192,10 @@ def run_ookla(app: SpeedtestZ) -> None:
                 except TimeoutException:
                     logger.debug("ookla: Privacy banner not found or not dismissed")
 
-            # Server Selection (best effort: written for the pre-2026 UI; the
-            # redesigned UI keeps a "Change Server" link but the surrounding
-            # selectors are unverified. Failures fall through to the default
-            # auto-selected server.)
+            # Server selection (best effort; falls through to the
+            # auto-selected server on any failure)
             if app.ookla_server is not None:
-                need_change = True
-                try:
-                    curr_srv_elem = WebDriverWait(app.driver, 10).until(
-                        EC.visibility_of_element_located((By.CLASS_NAME, "hostUrl"))
-                    )
-                    if app.ookla_server in curr_srv_elem.text:
-                        logger.info(f"ookla: Server match ({curr_srv_elem.text}).")
-                        need_change = False
-                except Exception as e:
-                    logger.debug(f"ookla: Could not read current server: {e}")
-
-                if need_change:
-                    logger.info("ookla: Search [Change Server]")
-                    is_success = False
-                    for _ in range(3):
-                        try:
-                            xp = app.wait.until(
-                                EC.element_to_be_clickable((By.LINK_TEXT, "Change Server"))
-                            )
-                            xp.click()
-                            is_success = True
-                            break
-                        except Exception as e:
-                            logger.debug(f"ookla: Change Server click retry: {e}")
-                            time.sleep(1)
-
-                    if not is_success:
-                        try:
-                            xp = app.driver.find_element(
-                                By.XPATH,
-                                "//a[contains(text(), 'Change Server')]",
-                            )
-                            app.driver.execute_script("arguments[0].click();", xp)
-                            is_success = True
-                        except Exception as e:
-                            logger.debug(f"ookla: Change Server JS fallback failed: {e}")
-
-                    if is_success:
-                        try:
-                            search_box = app.wait.until(
-                                EC.visibility_of_element_located((By.ID, "host-search"))
-                            )
-                            search_box.clear()
-                            search_box.send_keys(app.ookla_server)
-                            app.wait.until(
-                                EC.presence_of_element_located(
-                                    (
-                                        By.XPATH,
-                                        '//*[@id="find-servers"]//ul/li/a',
-                                    )
-                                )
-                            )
-                            time.sleep(1)
-                            server_list = app.driver.find_elements(
-                                By.XPATH,
-                                '//*[@id="find-servers"]//ul/li/a',
-                            )
-                            target_found = False
-                            for item in server_list:
-                                if app.ookla_server in item.text:
-                                    item.click()
-                                    target_found = True
-                                    break
-                            if not target_found and server_list:
-                                server_list[0].click()
-                        except Exception as e:
-                            logger.warning(f"ookla: Server selection failed: {e}")
+                _select_server(app)
 
             try:
                 start_btn = app.wait.until(EC.element_to_be_clickable(START_BUTTON))

--- a/speedtest_z/sites/ookla.py
+++ b/speedtest_z/sites/ookla.py
@@ -8,7 +8,11 @@ import re
 import time
 from typing import TYPE_CHECKING, Literal
 
-from selenium.common.exceptions import TimeoutException
+from selenium.common.exceptions import (
+    NoSuchElementException,
+    StaleElementReferenceException,
+    TimeoutException,
+)
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support import expected_conditions as EC
@@ -129,13 +133,19 @@ def _select_server(app: SpeedtestZ) -> None:
         search_box.send_keys(server)
 
         def _server_rows(driver: WebDriver) -> list[WebElement] | Literal[False]:
-            # Rows are div[role=button] list items; icon-only buttons (close,
-            # Select Automatically) are <button> tags or have no text
-            rows = [
-                r
-                for r in dialog.find_elements(By.CSS_SELECTOR, 'div[role="button"]')
-                if (r.text or "").strip()
-            ]
+            # Re-locate the dialog on every poll: a React re-render can
+            # replace the node and make a captured reference stale. Rows are
+            # div[role=button] list items; icon-only buttons (close, Select
+            # Automatically) are <button> tags or have no text.
+            try:
+                dlg = driver.find_element(By.CSS_SELECTOR, '[role="dialog"]')
+                rows = [
+                    r
+                    for r in dlg.find_elements(By.CSS_SELECTOR, 'div[role="button"]')
+                    if (r.text or "").strip()
+                ]
+            except (NoSuchElementException, StaleElementReferenceException):
+                return False
             return rows or False
 
         rows = WebDriverWait(app.driver, 10).until(_server_rows)

--- a/speedtest_z/sites/ookla.py
+++ b/speedtest_z/sites/ookla.py
@@ -90,6 +90,61 @@ def _clean_number(text: str) -> str:
     return token if re.fullmatch(r"[0-9]+(\.[0-9]+)?", token) else ""
 
 
+# Wait predicates below return Literal[False] (not None) for the miss case:
+# selenium's WebDriverWait.until() stubs narrow `Literal[False] | T` to `T`
+# (same convention as speedtest_z/sites/mlab.py).
+
+DIALOG_SELECTOR = '[role="dialog"]'
+
+
+def _visible_change_button(driver: WebDriver) -> WebElement | Literal[False]:
+    """Return the visible "Change Server" button, or False while absent.
+
+    The page renders two responsive variants of the button;
+    element_to_be_clickable would latch onto the first match even when it is
+    the hidden one, so pick whichever is actually displayed.
+    """
+    for btn in driver.find_elements(By.XPATH, "//button[normalize-space()='Change Server']"):
+        if btn.is_displayed() and btn.is_enabled():
+            return btn
+    return False
+
+
+def _server_rows(driver: WebDriver) -> list[WebElement] | Literal[False]:
+    """Return non-empty server rows in the dialog, or False while absent.
+
+    Re-locates the dialog on every poll: a React re-render can replace the
+    node and make a captured reference stale. Rows are div[role=button] list
+    items; icon-only buttons (close, Select Automatically) are <button> tags
+    or have no text.
+    """
+    try:
+        dlg = driver.find_element(By.CSS_SELECTOR, DIALOG_SELECTOR)
+        rows = [
+            r
+            for r in dlg.find_elements(By.CSS_SELECTOR, 'div[role="button"]')
+            if (r.text or "").strip()
+        ]
+    except (NoSuchElementException, StaleElementReferenceException):
+        return False
+    return rows or False
+
+
+def _close_dialog(app: SpeedtestZ) -> None:
+    """Close an open server dialog so it cannot block the GO button.
+
+    MUI dialogs trap focus inside themselves and close on Escape; also wait
+    for the node to disappear so a surviving overlay is at least logged.
+    """
+    try:
+        app.driver.switch_to.active_element.send_keys(Keys.ESCAPE)
+        WebDriverWait(app.driver, 3).until_not(
+            EC.presence_of_element_located((By.CSS_SELECTOR, DIALOG_SELECTOR))
+        )
+    except Exception as e:
+        logger.debug(f"ookla: Dialog close not confirmed: {e}")
+
+
 def _select_server(app: SpeedtestZ) -> None:
     """Pin the measurement server on the redesigned UI (best effort).
 
@@ -106,58 +161,43 @@ def _select_server(app: SpeedtestZ) -> None:
     if not server:
         return
 
-    def _visible_change_button(driver: WebDriver) -> WebElement | Literal[False]:
-        # The page renders two "Change Server" buttons (responsive variants);
-        # element_to_be_clickable would latch onto the first match even when
-        # it is the hidden one, so pick whichever is actually displayed.
-        for btn in driver.find_elements(By.XPATH, "//button[normalize-space()='Change Server']"):
-            if btn.is_displayed() and btn.is_enabled():
-                return btn
-        return False
-
     try:
         # The button appears only after "Finding optimal server..." resolves
         change_btn = WebDriverWait(app.driver, 15).until(_visible_change_button)
         change_btn.click()
         dialog = WebDriverWait(app.driver, 5).until(
-            EC.visibility_of_element_located((By.CSS_SELECTOR, '[role="dialog"]'))
+            EC.visibility_of_element_located((By.CSS_SELECTOR, DIALOG_SELECTOR))
         )
 
-        # The dialog header shows the currently selected server
-        if server.lower() in dialog.text[:150].lower():
+        # Only the dialog title names the currently selected server; the
+        # dialog body already lists nearby servers, so matching on the whole
+        # dialog text would false-positive when the target is merely nearby.
+        title_text = ""
+        with contextlib.suppress(NoSuchElementException):
+            title_text = dialog.find_element(By.CSS_SELECTOR, ".MuiDialogTitle-root").text
+        if server.lower() in title_text.lower():
             logger.info(f"ookla: Server already selected ({server}).")
-            app.driver.switch_to.active_element.send_keys(Keys.ESCAPE)
+            _close_dialog(app)
             return
 
         search_box = dialog.find_element(By.CSS_SELECTOR, 'input[type="text"]')
+        search_box.clear()
         search_box.send_keys(server)
 
-        def _server_rows(driver: WebDriver) -> list[WebElement] | Literal[False]:
-            # Re-locate the dialog on every poll: a React re-render can
-            # replace the node and make a captured reference stale. Rows are
-            # div[role=button] list items; icon-only buttons (close, Select
-            # Automatically) are <button> tags or have no text.
-            try:
-                dlg = driver.find_element(By.CSS_SELECTOR, '[role="dialog"]')
-                rows = [
-                    r
-                    for r in dlg.find_elements(By.CSS_SELECTOR, 'div[role="button"]')
-                    if (r.text or "").strip()
-                ]
-            except (NoSuchElementException, StaleElementReferenceException):
-                return False
-            return rows or False
-
         rows = WebDriverWait(app.driver, 10).until(_server_rows)
-        target = next((r for r in rows if server.lower() in r.text.lower()), rows[0])
+        target = next((r for r in rows if server.lower() in r.text.lower()), None)
+        if target is None:
+            # Do not click an arbitrary row: a wrong server pinned silently is
+            # worse than falling back to the auto-selected one.
+            logger.warning(f"ookla: No server row matched '{server}'; using auto-selected server.")
+            _close_dialog(app)
+            return
         label = target.text.splitlines()[0] if target.text else server
         target.click()
         logger.info(f"ookla: Server selected ({label})")
     except Exception as e:
         logger.warning(f"ookla: Server selection failed; using auto-selected server: {e}")
-        # Close a possibly-open dialog so it cannot block the GO button
-        with contextlib.suppress(Exception):
-            app.driver.switch_to.active_element.send_keys(Keys.ESCAPE)
+        _close_dialog(app)
 
 
 def run_ookla(app: SpeedtestZ) -> None:

--- a/tests/test_sites/test_ookla.py
+++ b/tests/test_sites/test_ookla.py
@@ -2,9 +2,15 @@
 
 from unittest.mock import MagicMock, patch
 
-from selenium.common.exceptions import TimeoutException
+from selenium.common.exceptions import NoSuchElementException, TimeoutException
 
-from speedtest_z.sites.ookla import _clean_number, _select_server, run_ookla
+from speedtest_z.sites.ookla import (
+    _clean_number,
+    _select_server,
+    _server_rows,
+    _visible_change_button,
+    run_ookla,
+)
 
 
 def _result(download="250.5", upload="80.3", ping="5"):
@@ -31,6 +37,45 @@ class TestCleanNumber:
         assert _clean_number("Mbps") == ""
 
 
+class TestWaitPredicates:
+    """Tests for the module-level wait predicates."""
+
+    def test_visible_change_button_picks_displayed_variant(self):
+        """The visible responsive variant is returned, not the hidden one."""
+        driver = MagicMock()
+        hidden = MagicMock()
+        hidden.is_displayed.return_value = False
+        visible = MagicMock()
+        visible.is_displayed.return_value = True
+        visible.is_enabled.return_value = True
+        driver.find_elements.return_value = [hidden, visible]
+        assert _visible_change_button(driver) is visible
+
+    def test_visible_change_button_false_when_absent(self):
+        """False is returned while no button is rendered."""
+        driver = MagicMock()
+        driver.find_elements.return_value = []
+        assert _visible_change_button(driver) is False
+
+    def test_server_rows_filters_empty_text(self):
+        """Only rows with non-empty text are returned."""
+        driver = MagicMock()
+        dlg = MagicMock()
+        driver.find_element.return_value = dlg
+        row = MagicMock()
+        row.text = "Tokyo - TestServer"
+        icon = MagicMock()
+        icon.text = ""
+        dlg.find_elements.return_value = [icon, row]
+        assert _server_rows(driver) == [row]
+
+    def test_server_rows_false_when_dialog_missing(self):
+        """False is returned when the dialog is gone (or went stale)."""
+        driver = MagicMock()
+        driver.find_element.side_effect = NoSuchElementException()
+        assert _server_rows(driver) is False
+
+
 class TestSelectServer:
     """Tests for _select_server() against the redesigned server dialog."""
 
@@ -40,6 +85,21 @@ class TestSelectServer:
         app.ookla_server = server
         return app
 
+    def _dialog(self, title_text, search_box=None):
+        """Build a dialog mock whose title and search input are separable."""
+        dialog = MagicMock()
+        title = MagicMock()
+        title.text = title_text
+        search = search_box if search_box is not None else MagicMock()
+
+        def _find(by, selector):
+            if "MuiDialogTitle" in selector:
+                return title
+            return search
+
+        dialog.find_element.side_effect = _find
+        return dialog
+
     def test_noop_when_server_unset(self):
         """Nothing happens when ookla_server is not configured."""
         app = self._app(server=None)
@@ -47,48 +107,40 @@ class TestSelectServer:
             _select_server(app)
         mock_wdw.assert_not_called()
 
-    def test_skips_dialog_when_already_selected(self):
-        """The dialog is closed without searching when the server matches."""
+    def test_skips_search_when_title_matches(self):
+        """The dialog is closed without searching when the title matches."""
         app = self._app()
         change_btn = MagicMock()
-        dialog = MagicMock()
-        dialog.text = "TESTSERVER Tokyo Select Automatically"
+        search_box = MagicMock()
+        dialog = self._dialog("TESTSERVER Tokyo", search_box=search_box)
         with patch("speedtest_z.sites.ookla.WebDriverWait") as mock_wdw:
             mock_wdw.return_value.until.side_effect = [change_btn, dialog]
             _select_server(app)
         change_btn.click.assert_called_once()
-        dialog.find_element.assert_not_called()
+        search_box.send_keys.assert_not_called()
 
-    def test_searches_and_selects_matching_row(self):
-        """The row whose text contains ookla_server is clicked."""
+    def test_nearby_list_match_does_not_skip_search(self):
+        """A target name in the body list (not the title) still searches."""
         app = self._app()
         change_btn = MagicMock()
-        dialog = MagicMock()
-        dialog.text = "OtherServer Tokyo Select Automatically"
         search_box = MagicMock()
-        dialog.find_element.return_value = search_box
-        row_other = MagicMock()
-        row_other.text = "Osaka - OtherServer"
+        # Title shows a DIFFERENT server; the old whole-text check would have
+        # false-positived if the target appeared in the nearby-server list.
+        dialog = self._dialog("OtherServer Tokyo", search_box=search_box)
         row_match = MagicMock()
         row_match.text = "Tokyo - TestServer 400G"
         with patch("speedtest_z.sites.ookla.WebDriverWait") as mock_wdw:
-            mock_wdw.return_value.until.side_effect = [
-                change_btn,  # Change Server button
-                dialog,  # dialog visible
-                [row_other, row_match],  # server rows
-            ]
+            mock_wdw.return_value.until.side_effect = [change_btn, dialog, [row_match]]
             _select_server(app)
+        search_box.clear.assert_called_once()
         search_box.send_keys.assert_called_once_with("TestServer")
         row_match.click.assert_called_once()
-        row_other.click.assert_not_called()
 
-    def test_falls_back_to_first_row_without_match(self):
-        """The first row is clicked when no row text matches."""
+    def test_no_match_falls_back_to_auto_without_clicking(self):
+        """No matching row: nothing is clicked and auto-select is kept."""
         app = self._app()
         change_btn = MagicMock()
-        dialog = MagicMock()
-        dialog.text = "OtherServer Tokyo"
-        dialog.find_element.return_value = MagicMock()
+        dialog = self._dialog("OtherServer Tokyo")
         row1 = MagicMock()
         row1.text = "Osaka - Alpha"
         row2 = MagicMock()
@@ -96,7 +148,8 @@ class TestSelectServer:
         with patch("speedtest_z.sites.ookla.WebDriverWait") as mock_wdw:
             mock_wdw.return_value.until.side_effect = [change_btn, dialog, [row1, row2]]
             _select_server(app)
-        row1.click.assert_called_once()
+        row1.click.assert_not_called()
+        row2.click.assert_not_called()
 
     def test_failure_is_nonfatal(self):
         """A missing Change Server button logs a warning and returns."""

--- a/tests/test_sites/test_ookla.py
+++ b/tests/test_sites/test_ookla.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 from selenium.common.exceptions import TimeoutException
 
-from speedtest_z.sites.ookla import _clean_number, run_ookla
+from speedtest_z.sites.ookla import _clean_number, _select_server, run_ookla
 
 
 def _result(download="250.5", upload="80.3", ping="5"):
@@ -29,6 +29,81 @@ class TestCleanNumber:
         assert _clean_number("") == ""
         assert _clean_number("—") == ""
         assert _clean_number("Mbps") == ""
+
+
+class TestSelectServer:
+    """Tests for _select_server() against the redesigned server dialog."""
+
+    def _app(self, server="TestServer"):
+        """Build a minimal mock app with ookla_server set."""
+        app = MagicMock()
+        app.ookla_server = server
+        return app
+
+    def test_noop_when_server_unset(self):
+        """Nothing happens when ookla_server is not configured."""
+        app = self._app(server=None)
+        with patch("speedtest_z.sites.ookla.WebDriverWait") as mock_wdw:
+            _select_server(app)
+        mock_wdw.assert_not_called()
+
+    def test_skips_dialog_when_already_selected(self):
+        """The dialog is closed without searching when the server matches."""
+        app = self._app()
+        change_btn = MagicMock()
+        dialog = MagicMock()
+        dialog.text = "TESTSERVER Tokyo Select Automatically"
+        with patch("speedtest_z.sites.ookla.WebDriverWait") as mock_wdw:
+            mock_wdw.return_value.until.side_effect = [change_btn, dialog]
+            _select_server(app)
+        change_btn.click.assert_called_once()
+        dialog.find_element.assert_not_called()
+
+    def test_searches_and_selects_matching_row(self):
+        """The row whose text contains ookla_server is clicked."""
+        app = self._app()
+        change_btn = MagicMock()
+        dialog = MagicMock()
+        dialog.text = "OtherServer Tokyo Select Automatically"
+        search_box = MagicMock()
+        dialog.find_element.return_value = search_box
+        row_other = MagicMock()
+        row_other.text = "Osaka - OtherServer"
+        row_match = MagicMock()
+        row_match.text = "Tokyo - TestServer 400G"
+        with patch("speedtest_z.sites.ookla.WebDriverWait") as mock_wdw:
+            mock_wdw.return_value.until.side_effect = [
+                change_btn,  # Change Server button
+                dialog,  # dialog visible
+                [row_other, row_match],  # server rows
+            ]
+            _select_server(app)
+        search_box.send_keys.assert_called_once_with("TestServer")
+        row_match.click.assert_called_once()
+        row_other.click.assert_not_called()
+
+    def test_falls_back_to_first_row_without_match(self):
+        """The first row is clicked when no row text matches."""
+        app = self._app()
+        change_btn = MagicMock()
+        dialog = MagicMock()
+        dialog.text = "OtherServer Tokyo"
+        dialog.find_element.return_value = MagicMock()
+        row1 = MagicMock()
+        row1.text = "Osaka - Alpha"
+        row2 = MagicMock()
+        row2.text = "Nagoya - Beta"
+        with patch("speedtest_z.sites.ookla.WebDriverWait") as mock_wdw:
+            mock_wdw.return_value.until.side_effect = [change_btn, dialog, [row1, row2]]
+            _select_server(app)
+        row1.click.assert_called_once()
+
+    def test_failure_is_nonfatal(self):
+        """A missing Change Server button logs a warning and returns."""
+        app = self._app()
+        with patch("speedtest_z.sites.ookla.WebDriverWait") as mock_wdw:
+            mock_wdw.return_value.until.side_effect = TimeoutException()
+            _select_server(app)  # must not raise
 
 
 class TestRunOokla:
@@ -286,8 +361,8 @@ class TestRunOokla:
 
         mock_app.send_results.assert_called_once()
 
-    def test_server_selection(self, mock_app):
-        """Server selection flow when ookla_server is set."""
+    def test_server_selection_invoked_when_configured(self, mock_app):
+        """_select_server is called once when ookla_server is set."""
         mock_app._should_run = MagicMock(return_value=True)
         mock_app._load_with_retry = MagicMock(return_value=True)
         mock_app.auto_consent = True
@@ -297,32 +372,20 @@ class TestRunOokla:
         mock_app.MAX_RETRIES = 1
         mock_app.driver.execute_script.return_value = _result()
 
-        server_elem = MagicMock()
-        server_elem.text = "CurrentServer"  # different from ookla_server
-        change_link = MagicMock()
-        search_box = MagicMock()
-        server_item = MagicMock()
-        server_item.text = "TestServer - Fast"
-
         with (
             patch("speedtest_z.sites.ookla.WebDriverWait") as mock_wdw,
             patch("speedtest_z.sites.ookla.time"),
+            patch("speedtest_z.sites.ookla._select_server") as mock_select,
         ):
             mock_wdw.return_value.until.side_effect = [
                 TimeoutException(),  # consent
-                server_elem,  # current server element
                 True,  # completion
             ]
-            mock_app.wait.until.side_effect = [
-                change_link,  # Change Server link
-                search_box,  # host-search box
-                MagicMock(),  # server list presence
-                MagicMock(),  # start button
-            ]
-            mock_app.driver.find_elements.return_value = [server_item]
+            mock_app.wait.until.return_value = MagicMock()
             run_ookla(mock_app)
 
-        server_item.click.assert_called_once()
+        mock_select.assert_called_once_with(mock_app)
+        mock_app.send_results.assert_called_once()
 
     def test_zabbix_host_in_data(self, mock_app):
         """Each data item includes the correct zabbix_host."""


### PR DESCRIPTION
## Summary

Closes #42. Also records the #41 decision as a code comment.

The old server-selection flow targeted pre-2026 selectors: `.hostUrl`, `LINK_TEXT "Change Server"` (the redesigned UI renders a `<button>`, which LINK_TEXT can never match), and `#host-search`/`#find-servers`. It burned waits and always fell through.

New `_select_server()` (flow live-verified in a human-driven browser on 2026-07-18):
1. Wait for the **visible** "Change Server" button — the page renders two responsive variants, so `element_to_be_clickable` on the XPath would latch onto the hidden one
2. Open the `[role="dialog"]`; if the dialog header already shows the configured server, close with ESC
3. Type into the dialog's single text input, wait for `div[role="button"]` result rows, click the matching row (first row as fallback)
4. Everything fails soft to the auto-selected server; a leftover dialog is closed with ESC so it cannot block the GO button

### Known limitation (documented in docstring + config.ini-sample)

Under automated (Selenium) Chrome, the pre-test server discovery stalls at "Finding optimal server..." (reproduced with the runner's exact profile/window size; 30s+ with no resolution), so the picker never renders and pinning falls back to auto-select after 15s. The same page resolves in seconds in a human-driven browser on the same network — consistent with automation detection. **No anti-detection flags are added, deliberately.** `ookla_server` is unset in production configs, so nothing regresses.

### #41 decision

A sustained top-page reload failure on retry (i.e. after `_load_with_retry`'s own 3 attempts) aborts the runner rather than burning the remaining 90s-per-attempt budget on an unreachable page. Recorded at the retry site.

## Testing

- `ruff` / `mypy` clean, `pytest` 341 passed (new `TestSelectServer`: unset-config no-op, already-selected skip, search-and-match, first-row fallback, non-fatal failure; run-level test asserts `_select_server` is invoked when configured)
- Live: `--dry-run --yes ookla` with `ookla_server = IPA CyberLab` — selection falls back with a single WARNING line and the measurement completes normally (download/upload/ping all sent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSZ4DStF9gZzjfbcyT7pmX