### PR TITLE
ci: attach release assets to a draft, then publish (immutable-ready)

### DIFF
--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -1,8 +1,16 @@
 name: Build .deb packages
 
+# Called from release-please.yml while the release is still a DRAFT so the
+# assets are attached before publishing (required for immutable releases —
+# assets cannot be added after publish). workflow_dispatch remains for
+# ad-hoc builds and uploads nothing.
 on:
-  release:
-    types: [published]
+  workflow_call:
+    inputs:
+      tag:
+        description: "Draft release tag to attach the .deb to (e.g. v0.8.1)"
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       version:
@@ -44,11 +52,12 @@ jobs:
       - name: Update debian/changelog version
         env:
           INPUT_VERSION: ${{ inputs.version }}
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
           if [ -n "$INPUT_VERSION" ]; then
             VERSION="$INPUT_VERSION"
           else
-            VERSION="${GITHUB_REF_NAME#v}"
+            VERSION="${INPUT_TAG#v}"
           fi
           # Prepend a proper changelog stanza (version, entry, maintainer, date)
           # instead of only rewriting the version of the existing top entry.
@@ -70,11 +79,12 @@ jobs:
             mv "$deb" "${deb%.deb}~${{ matrix.codename }}.deb"
           done
 
-      # The GitHub Release already exists (this workflow is triggered by
-      # release:published), so just attach the .deb assets to it.
+      # The release is still a draft at this point; gh resolves draft
+      # releases by tag name for users with push access.
       - name: Upload .deb to GitHub Release
-        if: github.event_name == 'release'
+        if: inputs.tag != ''
         env:
           GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag }}
         run: |
-          gh release upload "${GITHUB_REF_NAME}" ../speedtest-z_*~${{ matrix.codename }}.deb --clobber
+          gh release upload "$TAG" ../speedtest-z_*~${{ matrix.codename }}.deb --clobber

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -11,6 +11,10 @@ on:
         description: "Draft release tag to attach the .deb to (e.g. v0.8.1)"
         required: true
         type: string
+      sha:
+        description: "Commit to build from (the draft release's target)"
+        required: false
+        type: string
   workflow_dispatch:
     inputs:
       version:
@@ -31,9 +35,13 @@ jobs:
       contents: write
 
     steps:
+      # Build the exact commit the draft release targets, not whatever HEAD
+      # the calling run happens to sit on (empty on workflow_dispatch →
+      # default checkout).
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          ref: ${{ inputs.sha }}
 
       - name: Install build dependencies
         run: |

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,6 +8,13 @@ permissions:
   contents: write
   pull-requests: write
 
+# Never run two release pipelines at once: with draft releases a lost race
+# would create two drafts for the same tag (release-please's "already
+# released" check is label-based and happens after release creation).
+concurrency:
+  group: release-please
+  cancel-in-progress: false
+
 # Release flow (immutable-releases compatible):
 #   1. release-please creates the GitHub Release as a DRAFT ("draft": true in
 #      release-please-config.json). A draft has no git tag yet.
@@ -29,6 +36,7 @@ jobs:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
+      sha: ${{ steps.release.outputs.sha }}
     steps:
       # Maintains a release PR; merging it creates the vX.Y.Z DRAFT release.
       # Use a fine-grained PAT (RELEASE_PLEASE_TOKEN) so the release:published
@@ -49,6 +57,7 @@ jobs:
     uses: ./.github/workflows/deb.yml
     with:
       tag: ${{ needs.release-please.outputs.tag_name }}
+      sha: ${{ needs.release-please.outputs.sha }}
 
   rpm:
     needs: release-please
@@ -56,6 +65,7 @@ jobs:
     uses: ./.github/workflows/rpm.yml
     with:
       tag: ${{ needs.release-please.outputs.tag_name }}
+      sha: ${{ needs.release-please.outputs.sha }}
 
   publish-release:
     needs: [release-please, deb, rpm]

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,6 +8,17 @@ permissions:
   contents: write
   pull-requests: write
 
+# Release flow (immutable-releases compatible):
+#   1. release-please creates the GitHub Release as a DRAFT ("draft": true in
+#      release-please-config.json). A draft has no git tag yet.
+#   2. deb/rpm build against the merged commit (which contains the version
+#      bump) and attach their packages to the draft.
+#   3. publish-release flips the draft to published — that creates the tag
+#      and fires release:published, which triggers the PyPI pipeline
+#      (release.yml) exactly as before.
+# Assets must be attached BEFORE publishing: with immutable releases enabled,
+# a published release's assets can never be added, changed, or removed.
+
 jobs:
   release-please:
     runs-on: ubuntu-latest
@@ -15,15 +26,48 @@ jobs:
     # JST merge day rather than the runner's UTC clock (release-please respects TZ).
     env:
       TZ: Asia/Tokyo
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      # Maintains a release PR; merging it creates the vX.Y.Z tag and publishes
-      # the GitHub Release. Use a fine-grained PAT (RELEASE_PLEASE_TOKEN) so the
-      # release:published event triggers the downstream PyPI/deb/rpm workflows —
-      # a release created by the default GITHUB_TOKEN cannot trigger other
-      # workflows (GitHub's recursion-prevention rule). Falls back to
-      # GITHUB_TOKEN on forks / PR CI where the secret is unavailable.
+      # Maintains a release PR; merging it creates the vX.Y.Z DRAFT release.
+      # Use a fine-grained PAT (RELEASE_PLEASE_TOKEN) so the release:published
+      # event (emitted by publish-release below) triggers the downstream PyPI
+      # workflow — a release created by the default GITHUB_TOKEN cannot
+      # trigger other workflows (GitHub's recursion-prevention rule). Falls
+      # back to GITHUB_TOKEN on forks / PR CI where the secret is unavailable.
       - uses: googleapis/release-please-action@v5
+        id: release
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  deb:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    uses: ./.github/workflows/deb.yml
+    with:
+      tag: ${{ needs.release-please.outputs.tag_name }}
+
+  rpm:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    uses: ./.github/workflows/rpm.yml
+    with:
+      tag: ${{ needs.release-please.outputs.tag_name }}
+
+  publish-release:
+    needs: [release-please, deb, rpm]
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      # Publish with the PAT for the same recursion-guard reason as above:
+      # publishing is what creates the tag and emits release:published, and
+      # that event must be allowed to trigger release.yml.
+      - name: Publish draft release
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ needs.release-please.outputs.tag_name }}
+        run: gh release edit "$TAG" --draft=false

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -1,8 +1,16 @@
 name: Build RPM packages
 
+# Called from release-please.yml while the release is still a DRAFT so the
+# assets are attached before publishing (required for immutable releases —
+# assets cannot be added after publish). workflow_dispatch remains for
+# ad-hoc builds and uploads nothing.
 on:
-  release:
-    types: [published]
+  workflow_call:
+    inputs:
+      tag:
+        description: "Draft release tag to attach the .rpm to (e.g. v0.8.1)"
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       version:
@@ -28,7 +36,7 @@ jobs:
         run: gem install fpm
 
       - name: Install GitHub CLI
-        if: github.event_name == 'release'
+        if: inputs.tag != ''
         run: |
           dnf install -y 'dnf-command(config-manager)'
           dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
@@ -42,11 +50,14 @@ jobs:
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Extract version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
-          if [ -n "${{ inputs.version }}" ]; then
-            echo "VERSION=${{ inputs.version }}" >> "$GITHUB_ENV"
+          if [ -n "$INPUT_VERSION" ]; then
+            echo "VERSION=$INPUT_VERSION" >> "$GITHUB_ENV"
           else
-            echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
+            echo "VERSION=${INPUT_TAG#v}" >> "$GITHUB_ENV"
           fi
 
       - name: Build virtualenv
@@ -126,11 +137,12 @@ jobs:
           echo "=== Scripts ==="
           rpm -qp --scripts speedtest-z-*.rpm
 
-      # The GitHub Release already exists (this workflow is triggered by
-      # release:published), so just attach the .rpm asset to it.
+      # The release is still a draft at this point; gh resolves draft
+      # releases by tag name for users with push access.
       - name: Upload RPM to GitHub Release
-        if: github.event_name == 'release'
+        if: inputs.tag != ''
         env:
           GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag }}
         run: |
-          gh release upload "${GITHUB_REF_NAME}" speedtest-z-*.rpm --clobber
+          gh release upload "$TAG" speedtest-z-*.rpm --clobber

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -11,6 +11,10 @@ on:
         description: "Draft release tag to attach the .rpm to (e.g. v0.8.1)"
         required: true
         type: string
+      sha:
+        description: "Commit to build from (the draft release's target)"
+        required: false
+        type: string
   workflow_dispatch:
     inputs:
       version:
@@ -42,9 +46,13 @@ jobs:
           dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
           dnf install -y gh
 
+      # Build the exact commit the draft release targets, not whatever HEAD
+      # the calling run happens to sit on (empty on workflow_dispatch →
+      # default checkout).
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          ref: ${{ inputs.sha }}
 
       - name: Mark git directory as safe
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,10 +66,10 @@ python -m build
 ## CI/CD
 
 - `.github/workflows/ci.yml` — push/PR 時に構文チェック + ビルドテスト（Python 3.10〜3.14）
-- `.github/workflows/release-please.yml` — main への push 時に release-please が Release PR を維持。マージで `vX.Y.Z` タグと GitHub Release を自動作成
+- `.github/workflows/release-please.yml` — main への push 時に release-please が Release PR を維持。マージで GitHub Release を **draft** 作成 → deb/rpm を reusable workflow として呼び出し資産を添付 → `publish-release` ジョブが draft を公開（この時点で `vX.Y.Z` タグ作成）。draft → 添付 → 公開の順序は Immutable Releases 対応のため（公開後は資産の追加・変更・削除不可）
 - `.github/workflows/release.yml` — Release 公開時（`release: published`）に **TestPyPI（`testpypi` 環境ゲート）→ PyPI** の順で自動公開（Trusted Publishers）。`verify` ジョブで pyproject の version とタグの一致を確認し、公開後に `notify-homebrew` ジョブが `HOMEBREW_TAP_TOKEN` で shigechika/homebrew-tap の更新を dispatch する
-- `.github/workflows/deb.yml` — Release 公開時に jammy/noble 向け .deb ビルド → 当該 Release にアップロード（手動は workflow_dispatch）
-- `.github/workflows/rpm.yml` — Release 公開時に Rocky 9 向け .rpm ビルド（fpm）→ 当該 Release にアップロード（手動は workflow_dispatch）
+- `.github/workflows/deb.yml` — `release-please.yml` から `workflow_call`（tag 入力）で呼ばれ jammy/noble 向け .deb ビルド → draft Release にアップロード（手動は workflow_dispatch、添付なし）
+- `.github/workflows/rpm.yml` — 同じく `workflow_call` で Rocky 9 向け .rpm ビルド（fpm）→ draft Release にアップロード（手動は workflow_dispatch、添付なし）
 
 ## リリース手順（release-please）
 
@@ -78,9 +78,9 @@ python -m build
 1. **Conventional Commits** で main にマージする（`feat:` → minor、`fix:` → patch、`feat!:`/`BREAKING CHANGE` → 1.0 未満は minor）
 2. release-please が **Release PR** を自動で開く/更新する（次バージョン + CHANGELOG エントリを含む）
 3. README 等の更新が必要なら通常の PR で先に入れておく
-4. Release PR をマージすると `vX.Y.Z` タグと GitHub Release が公開され、その `release: published` イベントで `release.yml`（PyPI）・`deb.yml`・`rpm.yml` が発火する
+4. Release PR をマージすると GitHub Release が **draft** で作成され、`deb.yml`・`rpm.yml` が .deb/.rpm を draft に添付、完了後に `publish-release` ジョブが公開する（この時点で `vX.Y.Z` タグ作成）。公開の `release: published` イベントで `release.yml`（PyPI）が発火する
 
-**重要: Release 起動には PAT が必要。** release-please が `GITHUB_TOKEN` で公開した Release は他ワークフローを起動しない（GitHub の仕様）。リポジトリシークレット `RELEASE_PLEASE_TOKEN`（PAT もしくは GitHub App トークン）を設定すると、release-please が公開する Release の `release: published` で PyPI/deb/rpm が自動発火する。未設定時は release-please 自体は動くが、ビルド/公開は手動発火（`deb.yml`/`rpm.yml` の workflow_dispatch 等）が必要。
+**重要: Release 起動には PAT が必要。** `GITHUB_TOKEN` で公開した Release は他ワークフローを起動しない（GitHub の仕様）。リポジトリシークレット `RELEASE_PLEASE_TOKEN`（PAT もしくは GitHub App トークン）を設定すると、`publish-release` ジョブが公開する Release の `release: published` で PyPI パイプラインが自動発火する。未設定時は release-please 自体は動くが、PyPI 公開は手動発火が必要。
 
 **重要: PyPI はバージョンの上書きを許可しない。** release-please は常に新しいバージョンを採番するためこの問題は基本的に起きないが、公開済みバージョンの再公開はできない点に留意する。
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,8 @@ python -m build
 
 **重要: PyPI はバージョンの上書きを許可しない。** release-please は常に新しいバージョンを採番するためこの問題は基本的に起きないが、公開済みバージョンの再公開はできない点に留意する。
 
+**deb/rpm 失敗時の復旧**: 同じ run の **「Re-run failed jobs」** で再開する（draft への `--clobber` 再アップロードは冪等）。**「Re-run all jobs」は使わない** — release-please がリリース済みと判定して全ジョブ skip となり、draft が未公開のまま残る。座礁した draft の手動復旧は `gh release upload <tag> <資産>` → PAT（`RELEASE_PLEASE_TOKEN` 相当）で `gh release edit <tag> --draft=false`（`GITHUB_TOKEN` で公開すると release.yml が発火しない）。
+
 ## config.ini の設計
 
 - `[general]` の `dry_run`（旧名 `dryrun` もフォールバックでサポート）。`chrome_profile_dir`（Cookie/同意の永続化先、デフォルト `~/.config/speedtest-z/chrome-profile`）

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,6 +8,7 @@
       "include-v-in-tag": true,
       "include-component-in-tag": false,
       "bump-minor-pre-major": true,
+      "draft": true,
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## Summary

Restructure the release flow to **draft → attach assets → publish** so that
[Immutable Releases](https://github.blog/changelog/2025-10-28-immutable-releases-are-now-generally-available/)
can be enabled on this repository. Today the .deb/.rpm assets are uploaded
*after* the release is published (`release: published` → `gh release upload`),
which immutability forbids — an immutable release's assets can never be added,
changed, or removed after publish.

## New flow (all inside release-please.yml)

1. release-please creates the GitHub Release as a **draft**
   (`"draft": true` in release-please-config.json). A draft has no git tag yet.
2. `deb.yml` / `rpm.yml` are invoked as **reusable workflows** (`workflow_call`
   with `tag` / `sha` inputs), build the draft's target commit (which contains
   the version bump), and attach their packages to the draft.
3. A final `publish-release` job flips the draft to published with
   `gh release edit "$TAG" --draft=false` using `RELEASE_PLEASE_TOKEN` —
   publishing creates the tag and fires `release: published`, which triggers
   the PyPI pipeline (release.yml) **unchanged**.

## Changes

- `release-please-config.json` — add `"draft": true`
- `release-please.yml` — orchestrates draft → deb/rpm → publish; exposes
  `release_created` / `tag_name` / `sha` outputs; `concurrency` group so two
  racing runs can't create duplicate drafts for the same tag
- `deb.yml` / `rpm.yml` — `release:` trigger replaced by `workflow_call`
  (a post-publish run would fail against an immutable release);
  `workflow_dispatch` kept for ad-hoc builds (uploads nothing);
  checkout pinned to the draft's target commit; upload targets the draft by
  tag (`gh` resolves draft releases by tag name for users with push access)
- `CLAUDE.md` — release-flow documentation + failure-recovery runbook

## Review

CI is green (actionlint + shellcheck where configured). Copilot review is
unavailable this month (credits exhausted), so an adversarial multi-agent
review was run instead; all its findings are folded into the second commit:

- artifact `overwrite: true` (junos-ops only — re-running a failed job
  otherwise 409s on the previous attempt's artifact)
- `concurrency` group on the release pipeline (duplicate-draft race)
- build pinned to the draft's target `sha` (was: the calling run's HEAD)
- recovery runbook: use **"Re-run failed jobs"**; "Re-run all jobs" makes
  release-please report nothing-to-do and strands the draft unpublished
  (manual recovery: `gh release upload` + `gh release edit --draft=false`
  with the PAT)

## Notes / edge cases

- The PAT requirement is unchanged: `RELEASE_PLEASE_TOKEN` is now also used by
  `publish-release`, because a release published by the default `GITHUB_TOKEN`
  would not trigger release.yml (recursion-prevention rule). Without the
  secret the behavior degrades exactly as before (release exists, PyPI job
  must be dispatched manually).
- If a deb/rpm build fails, the release stays draft (nothing published,
  no tag). Uploads use `--clobber`, safe while the release is still a draft.
- After merge, Immutable Releases will be enabled on this repo
  (`gh api -X PUT repos/{owner}/{repo}/immutable-releases`); the next
  release-please release exercises the new path end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GziLteeQMYroRGPca5uCd3
