### PR TITLE
ci: drop the cross-repository reference from the ai-review header

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,9 +1,9 @@
 name: AI review
 
 # First-pass AI code review via a self-hosted OpenAI-compatible endpoint
-# (Azure AI Foundry v1 API). Fleet-rolled-out from jquants-mcp #532/#533,
-# where it was multi-agent reviewed and hardened. The prompt steers the model
-# toward repository-guidance violations, cross-file consistency and security.
+# (Azure AI Foundry v1 API). The prompt steers the model toward
+# repository-guidance violations, cross-file consistency and security, which
+# is a deliberately different lens from a generic review pass.
 #
 # Advisory only: every failure path soft-fails so this job can never block a
 # PR. Skips release-please version bumps (same-repo scoped — a fork controls


### PR DESCRIPTION
The header comment named another repository as the origin of this
workflow. It is not needed to understand or maintain the file, and
naming which repositories share a setup is information worth not
publishing. The rest of the header — what the job does, why it is
advisory-only, and which secrets it needs — is unchanged.

No behaviour change: comment lines only.