### PR TITLE
fix(release): set force-tag-creation to prevent a release-please loop

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "force-tag-creation": true,
   "packages": {
     ".": {
       "release-type": "python",


### PR DESCRIPTION
## Summary

Preventive fix, applied fleet-wide after diagnosing and fixing the same bug in `junos-ops`.

`release-please-config.json` uses `"draft": true` so `deb.yml`/`rpm.yml` can attach packages to the release before it becomes immutable. GitHub does not create a real git tag for a draft release until it's published. If a draft is ever slow to publish, or its asset-attach step fails, release-please's next run can't find a tagged "latest release" to anchor its diff and falls back to a full-history scan - which can misfire and propose an already-shipped version, colliding with that version's now-immutable release when assets are re-attached, and looping.

This repo hasn't hit the failure (all release-please.yml runs to date succeeded, no orphaned drafts, no `Release-As:` footers in history), but it has the identical `draft: true` + no `force-tag-creation` config and the same draft -> attach -> publish workflow shape as junos-ops did before it looped there.

## Change

Add top-level `"force-tag-creation": true` to `release-please-config.json` so draft releases get a real git tag immediately, giving release-please a stable anchor without waiting for publish. No other files need to change here (manifest/version/CHANGELOG are already consistent, unlike junos-ops which needed a resync).

## Test plan

- [ ] Confirm the next release-please run still opens/updates a normal forward-version PR
- [ ] Confirm its draft release gets a real git tag immediately (`git ls-remote --tags` before publish)
