### PR TITLE
fix: add explicit workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   verify:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Fixes the CodeQL `actions/missing-workflow-permissions` alert(s) by adding
a workflow-level `permissions: contents: read` default. No job needs a
broader grant.

Same fix already applied and verified in production on
shigechika/mcp-stdio#407 and 9 other fleet repos this week.

## Test plan

- [ ] CI passes on this PR.
