### PR TITLE
docs: add REVIEW.md review-severity rules

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,77 @@
+# Review rules for this repository
+
+Review rules on top of the reviewer's default focus. Three things:
+which findings are blocking here, which classes to report that the
+default focus would otherwise skip, and which are noise. The reasoning
+behind the rules lives in `.github/copilot-instructions.md` (its
+numbered focus items are cited below) and `CLAUDE.md`, which the
+reviewer also receives.
+
+## Always blocking
+
+- **A `run_*` site function that lets an exception escape (§1).**
+  `cli.py`'s main loop does not wrap each call, so an escaping
+  exception reaches the outer handler and aborts **every remaining site
+  in the batch**, not just the failing one. Every existing
+  `sites/*.py` module wraps its `run_*` body in a broad `try/except
+  Exception`. Do not assume a single uniform block shape when checking
+  this — `ookla.py` snapshots inside its own per-attempt retry loop
+  rather than in one `finally`.
+- **An extraction helper that can raise past its own `try`/`except`
+  (§2).** Values are scraped from live third-party DOM that changes
+  shape regularly, so the convention is to return `""` on any failure
+  and let the caller gate on it — `run_cloudflare`'s `if not download:
+  return` before building the payload. A possibly-empty value sent
+  straight to a backend without passing through `SenderManager.send()`'s
+  empty-value drop belongs here too: that filter is what keeps Zabbix,
+  Grafana and OTel consistent.
+- **A credential reaching a log line at any level, `debug` included
+  (§3).** `[zabbix] api_password`, `[grafana] token`, and OTel
+  `headers`, which may carry an `Authorization` value or API key. The
+  existing code logs only *whether* a scheme is plaintext
+  (`_is_plaintext_remote`) or *that* configuration is incomplete —
+  never the secret.
+- **A `zapi_lib.ZapiClient` caller that lets an exception escape, or
+  that guards only `ImportError` without also wrapping the API call
+  (§4).** `SenderManager.set_version_tag()` is optional and must stay
+  non-fatal: it no-ops on dry-run, on Zabbix disabled, and on a partial
+  credential set, and catches both a missing import and any
+  `ZapiError` / `ZapiAuthError` / network failure. A speed test run
+  must not fail because a version stamp could not be written.
+- **A new optional-backend import that is not lazy (§5).** `grafana`
+  (`cramjam`), `otel` (`opentelemetry-*`) and `zabbix-api` (`zapi-lib`)
+  are extras, each imported inside its own `try`/`except ImportError`
+  that logs the `pip install speedtest-z[...]` hint rather than
+  crashing when the section is enabled but the extra is absent.
+
+## Report even though the default focus would not
+
+- **A diff that adds or changes an extraction helper or site runner and
+  also touches `tests/` without a failure or edge case (§6)**, as
+  advisory: element missing, timeout, or DOM text in an unexpected
+  shape. This is precisely the regression class the sites are most
+  prone to, since the DOM belongs to somebody else. Judge it from the
+  diff only — you receive changed files, so a pull request that leaves
+  `tests/` alone may well be covered by tests you were not given.
+- **A test that would drive a real browser (§6).** The suite never
+  launches Chrome: `speedtest_z.runner.SpeedtestZ` and
+  `selenium.webdriver` are mocked through `unittest.mock`, via
+  `tests/conftest.py`'s `mock_app` / `mock_config` fixtures.
+- **An OTel or Grafana test that hard-fails when the optional
+  dependency is absent (§6)**, as advisory. Those tests are written to
+  skip cleanly instead.
+
+## Never report
+
+- **MCP-flavored advice.** A content envelope, stdio-safety checks, or
+  adversarial-LLM-input handling — none of that applies here. This is a
+  CLI that drives a browser and ships metrics, not an MCP server.
+- A request to hand-bump `pyproject.toml`'s `version` or edit
+  `CHANGELOG.md`. release-please manages both.
+- `.deb` / `.rpm` packaging (`debian/`, `rpm/`) and the release or
+  publish workflows. Those are release-time concerns, and `CLAUDE.md`'s
+  release-please section is authoritative for them rather than
+  re-derivation from the workflow YAML.
+- Anything `ruff check` or `ruff format` already fails the build on.
+  Both gate `speedtest_z/` and `tests/`, so restating a finding costs a
+  round trip and no information.


### PR DESCRIPTION
## Summary

Adds a `REVIEW.md` — the repository-specific review override supported
by `shigechika/ai-review` since v1.5.0. It overrides the reviewer's
default focus and severity calibration for this repository.

Part of the fleet rollout tracked in `shigechika/ai-review#52`. The
contract, and the seven drafting hazards found while piloting it on two
repositories, are documented in the "Writing a `REVIEW.md`" section of
that repository's README.

## What is in it, and what deliberately is not

A **severity and scope layer**: which findings are blocking here, which
classes to report that the reviewer's default focus would otherwise
skip, and which are noise. The reasoning stays in
`.github/copilot-instructions.md` and `CLAUDE.md`, both of which the
reviewer already receives as guidance, and this file cites them rather
than restating them. That is a correctness point, not tidiness: the
override wins by design, so a duplicated explanation would let a stale
sentence here out-rank a corrected one there indefinitely.

Nothing is invented — it is distilled from the review material this
repository already had, and **every identifier and CI claim was checked
against the code before being written down**.

## Applying the piloted hazards

The pilots produced thirteen findings against files that were supposed
to be straightforward distillations. The two that bite hardest, and how
this file handles them:

- **Rules must be decidable from what the reviewer actually receives.**
  There is no checkout: it gets the diff, the changed files at head
  (subject to count and byte caps, deny-listed ones dropped), guidance
  at base, and a truncated PR description. So any coverage-style rule
  here is judged from the diff alone — absent from the prompt is not
  evidence of absent from the repository.
- **Rules must be scoped to the code they govern.** An unscoped "never
  write to stdout" turns a deliberate CLI print into a blocking finding
  on correct code, and since the override outranks guidance, the
  guidance explaining the distinction cannot rescue it.

## When this takes effect

`REVIEW.md` is read at the **base** revision by design, so a pull
request cannot rewrite the rules it is reviewed against. **This pull
request is therefore still reviewed without it** — the rules apply from
the next pull request onward. A review here that looks unchanged is
expected.

To confirm it is picked up afterwards, look for
`::notice::REVIEW.md: sent N of M bytes` and a non-zero
`review_override=` in the context line of the `review` job log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015NkkQZiesYXG7gEUdbYGcm
